### PR TITLE
lastInsertId() returns wrong sequence number

### DIFF
--- a/inc/record.inc.php
+++ b/inc/record.inc.php
@@ -446,7 +446,7 @@ function add_domain($domain, $owner, $type, $slave_master, $zone_template)
 			$response = $db->query("INSERT INTO domains (name, type) VALUES (".$db->quote($domain, 'text').", ".$db->quote($type, 'text').")");
 			if (PEAR::isError($response)) { error($response->getMessage()); return false; }
 
-            if ($db_layer == 'MDB2' && $db_type == 'mysql') {
+            if ($db_layer == 'MDB2' && ($db_type == 'mysql' || $db_type == 'pgsql')) {
 			    $domain_id = $db->lastInsertId('domains', 'id');
             } else if ($db_layer == 'PDO' && $db_type == 'pgsql') {
                 $domain_id = $db->lastInsertId('domains_id_seq');

--- a/inc/templates.inc.php
+++ b/inc/templates.inc.php
@@ -343,7 +343,7 @@ function add_zone_templ_save_as($template_name, $description, $userid, $records,
 
 		$result = $db->exec($query);
 
-                if ($db_layer == 'MDB2' && $db_type == 'mysql') {
+                if ($db_layer == 'MDB2' && ($db_type == 'mysql' || $db_type == 'pgsql')) {
                     $zone_templ_id = $db->lastInsertId('zone_templ', 'id');
                 } else if ($db_layer == 'PDO' && $db_type == 'pgsql') {
                     $zone_templ_id = $db->lastInsertId('zone_templ_id_seq');

--- a/inc/users.inc.php
+++ b/inc/users.inc.php
@@ -635,7 +635,7 @@ function add_perm_templ($details) {
 	$response = $db->query($query);
 	if (PEAR::isError($response)) { error($response->getMessage()); return false; }
 
-    if ($db_layer == 'MDB2' && $db_type == 'mysql') {
+    if ($db_layer == 'MDB2' && ($db_type == 'mysql' || $db_type == 'pgsql')) {
         $perm_templ_id = $db->lastInsertId('perm_templ', 'id');
     } else if ($db_layer == 'PDO' && $db_type == 'pgsql') {
         $perm_templ_id = $db->lastInsertId('perm_templ_id_seq');


### PR DESCRIPTION
when using MDB2 mysql and pgsql are equal. i had an issue with triggers
and pgsql, $db->lastInsertId() was used and returned me the sequence
value of the trigger. with this patch i get the _right_ sequence value
