### PR TITLE
Small MySQL InnoDB Improvements

### DIFF
--- a/sql/poweradmin-mysql-db-structure.sql
+++ b/sql/poweradmin-mysql-db-structure.sql
@@ -11,9 +11,10 @@ CREATE TABLE `users` (
   PRIMARY KEY  (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
-LOCK TABLES `users` WRITE;
-INSERT INTO `users` VALUES (1,'admin','21232f297a57a5a743894a0e4a801fc3','Administrator','admin@example.net','Administrator with full rights.',1,1,0);
-UNLOCK TABLES;
+START TRANSACTION;
+    INSERT INTO `users`
+        VALUES (1,'admin','21232f297a57a5a743894a0e4a801fc3','Administrator','admin@example.net','Administrator with full rights.',1,1,0);
+COMMIT;
 
 CREATE TABLE `perm_items` (
   `id` int(11) NOT NULL auto_increment,

--- a/sql/powerdns-mysql-db-structure.sql
+++ b/sql/powerdns-mysql-db-structure.sql
@@ -1,9 +1,9 @@
 create table domains (
- id		 INT auto_increment,
- name		 VARCHAR(255) NOT NULL,
- master		 VARCHAR(128) DEFAULT NULL,
- last_check	 INT DEFAULT NULL,
- type		 VARCHAR(6) NOT NULL,
+ id	             INT auto_increment,
+ name		     VARCHAR(255) NOT NULL,
+ master		     VARCHAR(128) DEFAULT NULL,
+ last_check	     INT DEFAULT NULL,
+ `type`		     VARCHAR(6) NOT NULL,
  notified_serial INT DEFAULT NULL, 
  account         VARCHAR(40) DEFAULT NULL,
  primary key (id)
@@ -15,7 +15,7 @@ CREATE TABLE records (
   id              INT auto_increment,
   domain_id       INT DEFAULT NULL,
   name            VARCHAR(255) DEFAULT NULL,
-  type            VARCHAR(10) DEFAULT NULL,
+  `type`          VARCHAR(10) DEFAULT NULL,
   content         VARCHAR(64000) DEFAULT NULL,
   ttl             INT DEFAULT NULL,
   prio            INT DEFAULT NULL,


### PR DESCRIPTION
When insterting data on InnoDB tables there's no need to lock it. Just
wrap your DML in transactional statements and you're good.

Also, "type" is a reserved word of the SQL language. When used out-of-context it should be quoted.
