### PR TITLE
Adding support for submitting IPv4 and IPv6 update in a single request

### DIFF
--- a/dynamic_update.php
+++ b/dynamic_update.php
@@ -66,6 +66,7 @@ function safe($value) {
 function status_exit($status) {
     $verbose_codes = array(
         'badagent' => 'Your user agent is not valid.',
+        'badauth2' => 'No username available.',
         'badauth' => 'Invalid username or password.  Authentication failed.',
         'notfqdn' => 'The hostname you specified was not valid.',
         'dnserr' => 'A DNS error has occurred on our end.  We apologize for any inconvenience.',
@@ -109,14 +110,14 @@ if (!(isset($_SERVER)) && !$_SERVER['HTTP_USER_AGENT']) {
 
 // Grab username & password based on HTTP auth, alternatively the query string
 if (isset($_SERVER['PHP_AUTH_USER'])) {
-	$auth_username = $_SERVER['PHP_AUTH_USER'];
+    $auth_username = $_SERVER['PHP_AUTH_USER'];
 } elseif (isset($_REQUEST['username'])) {
-	$auth_username = $_REQUEST['username'];
+    $auth_username = $_REQUEST['username'];
 }
 if (isset($_SERVER['PHP_AUTH_PW'])) {
-	$auth_password = $_SERVER['PHP_AUTH_PW'];
+    $auth_password = $_SERVER['PHP_AUTH_PW'];
 } elseif (isset($_REQUEST['password'])) {
-	$auth_password = $_REQUEST['password'];
+    $auth_password = $_REQUEST['password'];
 }
 
 // If we still don't have a username, throw up
@@ -133,24 +134,38 @@ $hostname = safe($_REQUEST['hostname']);
 
 // Grab IP to use
 $given_ip = "";
+$given_ip6 = "";
 if (!empty($_REQUEST['myip'])) {
-	$given_ip = $_REQUEST['myip'];
-
+    $given_ip = $_REQUEST['myip'];
 } elseif (!empty($_REQUEST['ip'])) {
-	$given_ip = $_REQUEST['ip'];
+    $given_ip = $_REQUEST['ip'];
+}
+if (!empty($_REQUEST['myip6'])) {
+    $given_ip6 = $_REQUEST['myip6'];
+} elseif (!empty($_REQUEST['ip6'])) {
+    $given_ip6 = $_REQUEST['ip6'];
+}
 
+if (valid_ip_address($given_ip) === 'AAAA'){
+    $given_ip6 = $given_ip;
 }
-// Look for tag tograb the IP we coming from
-if ($given_ip == "whatismyip") {
-	$given_ip = $_SERVER['REMOTE_ADDR'];
+// Look for tag to grab the IP we coming from
+if (($given_ip6 == "whatismyip")&&(valid_ip_address($_SERVER['REMOTE_ADDR']) === 'AAAA')){
+    $given_ip6 = $_SERVER['REMOTE_ADDR'];
 }
-// Finally get save version of the IP
+if (($given_ip == "whatismyip")&&(valid_ip_address($_SERVER['REMOTE_ADDR']) === 'A')){
+    $given_ip = $_SERVER['REMOTE_ADDR'];
+}elseif (($given_ip == "whatismyip")&&(valid_ip_address($_SERVER['REMOTE_ADDR']) === 'AAAA')&&(!(valid_ip_address($given_ip6) === 'AAAA'))){
+    $given_ip6 = $_SERVER['REMOTE_ADDR'];
+    echo "testtest";
+}
+
+// Finally get safe version of the IP
 $ip = safe($given_ip);
+$ip6 = safe($given_ip6);
 // Check its ok...
-if (!valid_ip_address($ip)) {
+if ( (!valid_ip_address($ip)) && (!valid_ip_address($ip6)) ) {
     return status_exit('dnserr');
-}else {
-    $type = valid_ip_address($ip);
 }
 
 if (!strlen($hostname)) {
@@ -158,43 +173,63 @@ if (!strlen($hostname)) {
 }
 
 $user_query = "
-	SELECT
-		users.id
-	FROM
-		users, perm_templ, perm_templ_items, perm_items
-	WHERE
-		users.username = '$username'
-		AND users.password = '$password'
-		AND users.active = 1
-		AND perm_templ.id = users.perm_templ
-		AND perm_templ_items.templ_id = perm_templ.id
-		AND perm_items.id = perm_templ_items.perm_id
-		AND (
-				perm_items.name = 'zone_content_edit_own'
-				OR perm_items.name = 'zone_content_edit_others'
-		)
+    SELECT
+        users.id
+    FROM
+        users, perm_templ, perm_templ_items, perm_items
+    WHERE
+        users.username = '$username'
+        AND users.password = '$password'
+        AND users.active = 1
+        AND perm_templ.id = users.perm_templ
+        AND perm_templ_items.templ_id = perm_templ.id
+        AND perm_items.id = perm_templ_items.perm_id
+        AND (
+                perm_items.name = 'zone_content_edit_own'
+                OR perm_items.name = 'zone_content_edit_others'
+        )
 ";
 $user = $db->queryRow($user_query);
 if (!$user) {
-    return status_exit('badauth');
+    return status_exit('badauth2');
 }
 
 $zones_query = "SELECT domain_id FROM zones WHERE owner='{$user["id"]}'";
 $zones_result = $db->query($zones_query);
 $was_updated = false;
+$no_update_necessary = false;
 
 while ($zone = $zones_result->fetchRow()) {
-    $name_query = "SELECT name FROM records WHERE domain_id='{$zone["domain_id"]}' and type = '$type'";
+    $zone_updated = false;
+    $name_query = "SELECT name, type, content FROM records WHERE domain_id='{$zone["domain_id"]}' and type = 'A' OR type = 'AAAA' ";
     $result = $db->query($name_query);
 
     while ($record = $result->fetchRow()) {
         if ($hostname == $record['name']) {
-            $update_query = "UPDATE records SET content ='{$ip}' where name='{$record["name"]}' and type='$type'";
-            $update_result = $db->query($update_query);
-            update_soa_serial($zone['domain_id']);
-            $was_updated = true;
+            if (($record['type'] == 'A')&&(valid_ip_address($ip) === 'A')) {
+                if ($ip == $record['content']) {
+                    $no_update_necessary = true;
+                }else{
+                    $update_query = "UPDATE records SET content ='{$ip}' where name='{$record["name"]}' and type='A'";
+                    $update_result = $db->query($update_query);
+                    $zone_updated = true;
+                    $was_updated = true;
+                }
+            }elseif (($record['type'] == 'AAAA')&&(valid_ip_address($ip6) === 'AAAA')) {
+                if ($ip6 == $record['content']) {
+                    $no_update_necessary = true;
+                }else{
+                    $update_query = "UPDATE records SET content ='{$ip6}' where name='{$record["name"]}' and type='AAAA'";
+                    $update_result = $db->query($update_query);
+                    $zone_updated = true;
+                    $was_updated = true;
+                }
+            }
         }
+    }
+    if($zone_updated){
+        update_soa_serial($zone['domain_id']);
     }
 }
 
-return ($was_updated ? status_exit('good') : status_exit('!yours'));
+return (($was_updated||$no_update_necessary) ? status_exit('good') : status_exit('!yours'));

--- a/dynamic_update.php
+++ b/dynamic_update.php
@@ -66,8 +66,8 @@ function safe($value) {
 function status_exit($status) {
     $verbose_codes = array(
         'badagent' => 'Your user agent is not valid.',
-        'badauth2' => 'No username available.',
-        'badauth' => 'Invalid username or password.  Authentication failed.',
+        'badauth' => 'No username available.',
+        'badauth2' => 'Invalid username or password.  Authentication failed.',
         'notfqdn' => 'The hostname you specified was not valid.',
         'dnserr' => 'A DNS error has occurred on our end.  We apologize for any inconvenience.',
         '!yours' => 'The specified hostname does not belong to you.',
@@ -157,7 +157,6 @@ if (($given_ip == "whatismyip")&&(valid_ip_address($_SERVER['REMOTE_ADDR']) === 
     $given_ip = $_SERVER['REMOTE_ADDR'];
 }elseif (($given_ip == "whatismyip")&&(valid_ip_address($_SERVER['REMOTE_ADDR']) === 'AAAA')&&(!(valid_ip_address($given_ip6) === 'AAAA'))){
     $given_ip6 = $_SERVER['REMOTE_ADDR'];
-    echo "testtest";
 }
 
 // Finally get safe version of the IP

--- a/locale/de_DE/LC_MESSAGES/de.po
+++ b/locale/de_DE/LC_MESSAGES/de.po
@@ -913,7 +913,7 @@ msgid "User is allowed to add new master zones."
 msgstr "Benutzer ist berechtigt neue Master Zonen hinzuzuf&uuml;gen."
 
 msgid "User is allowed to add new slave zones."
-msgstr "Benutzer ist berechtigt neue Salve Zonen hinzuzuf&uuml;gen."
+msgstr "Benutzer ist berechtigt neue Slave Zonen hinzuzuf&uuml;gen."
 
 msgid "User is allowed to see the content and meta data of zones he owns."
 msgstr "Benutzer ist berechtigt den Inhalt und die Meta Daten seiner Zonen anzuzeigen."


### PR DESCRIPTION
Adding support for submitting IPv4 and IPv6 update for a host in a single request while avoiding unnecessary updates. Full backwards compatibility to old single-address update queries.
- specify both v4 and v6 address (?hostname=HOSTNAME&ip=IPv4&ip6=IPv6)
- specify one request to get the address connecting from (?hostname=HOSTNAME&ip=whatismyip) or (?hostname=HOSTNAME&ip6=whatismyip) 
- specify either one of the and get the other one from the connection (?hostname=HOSTNAME&ip=IPv4&ip6=whatismyip) or (?hostname=HOSTNAME&ip=whatismyip&ip6=IPv6)


-EDIT: angled bracket not displayed