### PR TITLE
mysql should use utf8

### DIFF
--- a/inc/PDOLayer.php
+++ b/inc/PDOLayer.php
@@ -40,7 +40,7 @@ class PEAR {
      * Overrided isError method
      */
     public static function isError() {
-        
+
     }
 
 }
@@ -137,7 +137,7 @@ class PDOLayer extends PDOCommon {
      * Dummy method
      */
     public function disconnect() {
-        
+
     }
 
     /**
@@ -222,9 +222,20 @@ class PDOLayer extends PDOCommon {
 
         $query = "CREATE TABLE $name (" . implode(', ', $query_fields) . ')';
 
-        if ($db_type == 'mysql' && isset($options['type'])) {
-            $query .= ' ENGINE=' . $options['type'];
+        if ($db_type == 'mysql') {
+            if (isset($options['type'])) {
+                $query .= ' ENGINE=' . $options['type'];
+            }
+
+            if (isset($options['default_charset'])) {
+                $query .= ' DEFAULT CHARSET=' . $options['default_charset'];
+            }
+
+            if (isset($options['collate'])) {
+                $query .= ' COLLATE=' . $options['collate'];
+            }
         }
+
         $this->exec($query);
     }
 

--- a/inc/database.inc.php
+++ b/inc/database.inc.php
@@ -131,7 +131,16 @@ function dbConnect() {
         $dsn = "$db_type:host=$db_host;port=$db_port;dbname=$db_name";
     }
 
+    if ($db_type === 'mysql') {
+        $dsn .= ';charset=utf8';
+    }
+
     $db = new PDOLayer($dsn, $db_user, $db_pass);
+
+    // http://stackoverflow.com/a/4361485/567193
+    if ($db_type === 'mysql' && version_compare(phpversion(), '5.3.6', '<')) {
+        $db->exec('set names utf8');
+    }
 
     if (isset($db_debug) && $db_debug) {
         $db->setOption('debug', 1);

--- a/install/database-structure.inc.php
+++ b/install/database-structure.inc.php
@@ -3,7 +3,7 @@
 $def_tables = array(
     array(
         'table_name' => 'perm_items',
-        'options' => array('type' => 'innodb'),
+        'options' => array('type' => 'innodb', 'default_charset' => 'utf8', 'collate' => 'utf8_unicode_ci'),
         'fields' => array(
             'id' => array(
                 'type' => 'integer',
@@ -38,7 +38,7 @@ $def_tables = array(
     ),
     array(
         'table_name' => 'perm_templ',
-        'options' => array('type' => 'innodb'),
+        'options' => array('type' => 'innodb', 'default_charset' => 'utf8', 'collate' => 'utf8_unicode_ci'),
         'fields' => array(
             'id' => array(
                 'type' => 'integer',
@@ -74,7 +74,7 @@ $def_tables = array(
     ),
     array(
         'table_name' => 'perm_templ_items',
-        'options' => array('type' => 'innodb'),
+        'options' => array('type' => 'innodb', 'default_charset' => 'utf8', 'collate' => 'utf8_unicode_ci'),
         'fields' => array(
             'id' => array(
                 'notnull' => 1,
@@ -110,7 +110,7 @@ $def_tables = array(
     ),
     array(
         'table_name' => 'users',
-        'options' => array('type' => 'innodb'),
+        'options' => array('type' => 'innodb', 'default_charset' => 'utf8', 'collate' => 'utf8_unicode_ci'),
         'fields' => array(
             'id' => array
                 (
@@ -215,7 +215,7 @@ $def_tables = array(
     ),
     array(
         'table_name' => 'zones',
-        'options' => array('type' => 'innodb'),
+        'options' => array('type' => 'innodb', 'default_charset' => 'utf8', 'collate' => 'utf8_unicode_ci'),
         'fields' => array(
             'id' => array
                 (
@@ -276,7 +276,7 @@ $def_tables = array(
     ),
     array(
         'table_name' => 'zone_templ',
-        'options' => array('type' => 'innodb'),
+        'options' => array('type' => 'innodb', 'default_charset' => 'utf8', 'collate' => 'utf8_unicode_ci'),
         'fields' => array(
             'id' => array
                 (
@@ -327,7 +327,7 @@ $def_tables = array(
     ),
     array(
         'table_name' => 'zone_templ_records',
-        'options' => array('type' => 'innodb'),
+        'options' => array('type' => 'innodb', 'default_charset' => 'utf8', 'collate' => 'utf8_unicode_ci'),
         'fields' => array(
             'id' => array
                 (
@@ -411,7 +411,7 @@ $def_tables = array(
     ),
     array(
         'table_name' => 'records_zone_templ',
-        'options' => array('type' => 'innodb'),
+        'options' => array('type' => 'innodb', 'default_charset' => 'utf8', 'collate' => 'utf8_unicode_ci'),
         'fields' => array(
             'domain_id' => array
                 (
@@ -450,7 +450,7 @@ $def_tables = array(
     ),
     array(
         'table_name' => 'migrations',
-        'options' => array('type' => 'innodb'),
+        'options' => array('type' => 'innodb', 'default_charset' => 'utf8', 'collate' => 'utf8_unicode_ci'),
         'fields' => array(
             'domain_id' => array
                 (

--- a/sql/poweradmin-mysql-db-structure.sql
+++ b/sql/poweradmin-mysql-db-structure.sql
@@ -13,7 +13,7 @@ CREATE TABLE users (
   active      TINYINT      NOT NULL,
   use_ldap    TINYINT      NOT NULL,
   PRIMARY KEY (id)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 START TRANSACTION;
     INSERT INTO users ( id, username, `password`, fullname, email
@@ -27,7 +27,7 @@ CREATE TABLE perm_items (
   name VARCHAR(64) NOT NULL,
   descr TEXT       NOT NULL,
   PRIMARY KEY (id)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 START TRANSACTION;
     INSERT INTO perm_items ( id, name, descr ) VALUES ( 41, 'zone_master_add', 'User is allowed to add new master zones.' );
@@ -58,7 +58,7 @@ CREATE TABLE perm_templ (
   name  VARCHAR(128) NOT NULL,
   descr TEXT         NOT NULL,
   PRIMARY KEY  (id)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 START TRANSACTION;
     INSERT INTO perm_templ ( id, name, descr )
@@ -71,7 +71,7 @@ CREATE TABLE perm_templ_items (
   templ_id INTEGER NOT NULL,
   perm_id INTEGER  NOT NULL,
   PRIMARY KEY (id)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 START TRANSACTION;
     INSERT INTO perm_templ_items ( id, templ_id, perm_id )
@@ -86,7 +86,7 @@ CREATE TABLE zones (
   zone_templ_id INTEGER NOT NULL,
   PRIMARY KEY (id),
   KEY owner (owner)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE zone_templ (
   id    INTEGER      NOT NULL AUTO_INCREMENT,
@@ -94,7 +94,7 @@ CREATE TABLE zone_templ (
   descr TEXT         NOT NULL,
   owner INTEGER      NOT NULL,
   PRIMARY KEY (id)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE zone_templ_records (
   id            INTEGER      NOT NULL AUTO_INCREMENT,
@@ -105,15 +105,15 @@ CREATE TABLE zone_templ_records (
   ttl           INTEGER      NOT NULL,
   prio          INTEGER      NOT NULL,
   PRIMARY KEY (id)
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE records_zone_templ (
     domain_id INTEGER NOT NULL,
     record_id INTEGER NOT NULL,
     zone_templ_id INTEGER NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE migrations (
     version VARCHAR(255) NOT NULL,
     apply_time INTEGER NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
There is no reason nowadays for MySQL tables to not have utf8 as charset - especially the connection of the client should "talk utf8".

The pages already make usage of utf8 (via header + html).

This might not be backward compatible (for example if you were using non-ascii chars as username).