### PR TITLE
fixes #50

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -229,7 +229,7 @@ if ($records == "-1") {
         }
         elseif ($r['type'] == "SOA" && $perm_content_edit != "all" || ($r['type'] == "NS" && $perm_content_edit == "own_as_client")) {
         	echo "     <td class=\"n\">&nbsp;</td>\n";
-        }        
+        }
         else {
             echo "     <td class=\"n\">\n";
             echo "      <a href=\"edit_record.php?id=" . $r['id'] . "&amp;domain=" . $zone_id . "\">
@@ -261,17 +261,10 @@ if ($records == "-1") {
             }
             if (!$found_selected_type)
                 echo "         <option SELECTED value=\"" . htmlspecialchars($r['type']) . "\"><i>" . $r['type'] . "</i></option>\n";
-            /*
-              Sanitize content due to SPF record quoting in PowerDNS
-             */
-            if ($r['type'] == "SRV" || $r['type'] == "SPF" || $r['type'] == "TXT") {
-                $clean_content = trim($r['content'], "\x22\x27");
-            } else {
-                $clean_content = $r['content'];
-            }
+
             echo "       </select>\n";
             echo "      </td>\n";
-            echo "      <td class=\"u\"><input class=\"wide\" name=\"record[" . $r['id'] . "][content]\" value=\"" . htmlspecialchars($clean_content) . "\"></td>\n";
+            echo "      <td class=\"u\"><input class=\"wide\" name=\"record[" . $r['id'] . "][content]\" value=\"" . htmlspecialchars($r['content']) . "\"></td>\n";
             echo "      <td class=\"u\"><input size=\"4\" id=\"priority_field_" . $r['id'] . "\" name=\"record[" . $r['id'] . "][prio]\" value=\"" . htmlspecialchars($r['prio']) . "\"></td>\n";
             echo "      <td class=\"u\"><input size=\"4\" name=\"record[" . $r['id'] . "][ttl]\" value=\"" . htmlspecialchars($r['ttl']) . "\"></td>\n";
         }

--- a/edit_record.php
+++ b/edit_record.php
@@ -82,7 +82,7 @@ if (isset($_POST["commit"])) {
                              .' old_record_type:%s old_record:%s old_content:%s old_ttl:%s old_priority:%s'
                              .' record_type:%s record:%s content:%s ttl:%s priority:%s',
                               $_SERVER['REMOTE_ADDR'], $_SESSION["userlogin"],
-                              $old_record_info['type'], $old_record_info['name'], $old_record_info['content'], $old_record_info['ttl'], $old_record_info['prio'], 
+                              $old_record_info['type'], $old_record_info['name'], $old_record_info['content'], $old_record_info['ttl'], $old_record_info['prio'],
                               $new_record_info['type'], $new_record_info['name'], $new_record_info['content'], $new_record_info['ttl'], $new_record_info['prio']));
 
             if ($pdnssec_use) {
@@ -111,21 +111,12 @@ if ($perm_view == "none" || $perm_view == "own" && $user_is_zone_owner == "0") {
     echo "        <th>" . _('TTL') . "</th>\n";
     echo "       </tr>\n";
 
-    /*
-      Sanitize content due to SPF record quoting in PowerDNS
-     */
-    if ($record['type'] == "SRV" || $record['type'] == "SPF" || $record['type'] == "TXT") {
-        $clean_content = trim($record['content'], "\x22\x27");
-    } else {
-        $clean_content = $record['content'];
-    }
-
     if ($zone_type == "SLAVE" || $perm_content_edit == "none" || ($perm_content_edit == "own" || $perm_content_edit == "own_as_client") && $user_is_zone_owner == "0") {
         echo "      <tr>\n";
         echo "       <td>" . $record["name"] . "</td>\n";
         echo "       <td>IN</td>\n";
         echo "       <td>" . htmlspecialchars($record["type"]) . "</td>\n";
-        echo "       <td>" . htmlspecialchars($clean_content) . "</td>\n";
+        echo "       <td>" . htmlspecialchars($record['content']) . "</td>\n";
         echo "       <td>" . htmlspecialchars($record["prio"]) . "</td>\n";
         echo "       <td>" . htmlspecialchars($record["ttl"]) . "</td>\n";
         echo "      </tr>\n";
@@ -151,7 +142,7 @@ if ($perm_view == "none" || $perm_view == "own" && $user_is_zone_owner == "0") {
             echo "         <option SELECTED value=\"" . htmlspecialchars($record['type']) . "\"><i>" . $record['type'] . "</i></option>\n";
         echo "        </select>\n";
         echo "       </td>\n";
-        echo "       <td><input type=\"text\" name=\"content\" value=\"" . htmlspecialchars($clean_content) . "\" class=\"input\"></td>\n";
+        echo "       <td><input type=\"text\" name=\"content\" value=\"" . htmlspecialchars($record['content']) . "\" class=\"input\"></td>\n";
         echo "       <td><input type=\"text\" name=\"prio\" value=\"" . htmlspecialchars($record["prio"]) . "\" class=\"sinput\"></td>\n";
         echo "       <td><input type=\"text\" name=\"ttl\" value=\"" . htmlspecialchars($record["ttl"]) . "\" class=\"sinput\"></td>\n";
         echo "      </tr>\n";

--- a/inc/record.inc.php
+++ b/inc/record.inc.php
@@ -372,7 +372,7 @@ function edit_record($record) {
 
     $user_is_zone_owner = do_hook('verify_user_is_owner_zoneid', $record['zid']);
     $zone_type = get_domain_type($record['zid']);
-    
+
     if($record['type'] == 'SOA' && $perm_content_edit == "own_as_client"){
     	error(ERR_PERM_EDIT_RECORD_SOA);
     	return false;
@@ -389,15 +389,10 @@ function edit_record($record) {
         global $db;
         if (validate_input($record['rid'], $record['zid'], $record['type'], $record['content'], $record['name'], $record['prio'], $record['ttl'])) {
             $name = strtolower($record['name']); // powerdns only searches for lower case records
-            if ($record['type'] == "SPF" || $record['type'] == "TXT") {
-                $content = $db->quote(stripslashes('\"' . $record['content'] . '\"'), 'text');
-            } else {
-                $content = $db->quote($record['content'], 'text');
-            }
             $query = "UPDATE records
 				SET name=" . $db->quote($name, 'text') . ",
 				type=" . $db->quote($record['type'], 'text') . ",
-				content=" . $content . ",
+				content=" . $db->quote($record['content'], 'text') . ",
 				ttl=" . $db->quote($record['ttl'], 'integer') . ",
 				prio=" . $db->quote($record['prio'], 'integer') . ",
 				change_date=" . $db->quote(time(), 'integer') . "
@@ -450,17 +445,11 @@ function add_record($zone_id, $name, $type, $content, $ttl, $prio) {
         $response = $db->beginTransaction();
         if (validate_input(-1, $zone_id, $type, $content, $name, $prio, $ttl)) {
             $change = time();
-            $name = strtolower($name); // powerdns only searches for lower case records
-            if ($type == "SPF" || $type == "TXT") {
-                $content = $db->quote(stripslashes('\"' . $content . '\"'), 'text');
-            } else {
-                $content = $db->quote($content, 'text');
-            }
             $query = "INSERT INTO records (domain_id, name, type, content, ttl, prio, change_date) VALUES ("
                     . $db->quote($zone_id, 'integer') . ","
                     . $db->quote($name, 'text') . ","
                     . $db->quote($type, 'text') . ","
-                    . $content . ","
+                    . $db->quote($content, 'text') . ","
                     . $db->quote($ttl, 'integer') . ","
                     . $db->quote($prio, 'integer') . ","
                     . $db->quote($change, 'integer') . ")";
@@ -1642,7 +1631,7 @@ function search_zone_and_record($search_string, $perm, $zone_sortby = 'name', $r
     } else {
         $perm_view = "none";
     }
-    
+
     //redundant?
     if (do_hook('verify_permission' , 'zone_content_edit_others' )) {
         $perm_content_edit = "all";

--- a/inc/templates.inc.php
+++ b/inc/templates.inc.php
@@ -308,16 +308,11 @@ function add_zone_templ_record($zone_templ_id, $name, $type, $content, $ttl, $pr
         }
 
         if ($name != '') {
-            if ($type == "SPF") {
-                $content = $db->quote(stripslashes('\"' . $content . '\"'), 'text');
-            } else {
-                $content = $db->quote($content, 'text');
-            }
             $query = "INSERT INTO zone_templ_records (zone_templ_id, name, type, content, ttl, prio) VALUES ("
                     . $db->quote($zone_templ_id, 'integer') . ","
                     . $db->quote($name, 'text') . ","
                     . $db->quote($type, 'text') . ","
-                    . $content . ","
+                    . $db->quote($content, 'text') . ","
                     . $db->quote($ttl, 'integer') . ","
                     . $db->quote($prio, 'integer') . ")";
             $result = $db->query($query);
@@ -350,15 +345,10 @@ function edit_zone_templ_record($record) {
         return false;
     } else {
         if ("" != $record['name']) {
-            if ($record['type'] == "SPF") {
-                $content = $db->quote(stripslashes('\"' . $record['content'] . '\"'), 'text');
-            } else {
-                $content = $db->quote($record['content'], 'text');
-            }
             $query = "UPDATE zone_templ_records
                                 SET name=" . $db->quote($record['name'], 'text') . ",
                                 type=" . $db->quote($record['type'], 'text') . ",
-                                content=" . $content . ",
+                                content=" . $db->quote($record['content'], 'text') . ",
                                 ttl=" . $db->quote($record['ttl'], 'integer') . ",
                                 prio=" . $db->quote(isset($record['prio']) ? $record['prio'] : 0, 'integer') . "
                                 WHERE id=" . $db->quote($record['rid'], 'integer');
@@ -459,11 +449,6 @@ function add_zone_templ_save_as($template_name, $description, $userid, $records,
         $owner = get_zone_templ_is_owner($zone_templ_id, $_SESSION['userid']);
 
         foreach ($records as $record) {
-            if ($record['type'] == "SPF") {
-                $content = $db->quote(stripslashes('\"' . $record['content'] . '\"'), 'text');
-            } else {
-                $content = $db->quote($record['content'], 'text');
-            }
 
             $name = $domain ? preg_replace('/' . $domain . '/', '[ZONE]', $record['name']) : $record['name'];
             $content = $domain ? preg_replace('/' . $domain . '/', '[ZONE]', $content) : $content;
@@ -472,7 +457,7 @@ function add_zone_templ_save_as($template_name, $description, $userid, $records,
                     . $db->quote($zone_templ_id, 'integer') . ","
                     . $db->quote($name, 'text') . ","
                     . $db->quote($record['type'], 'text') . ","
-                    . $content . ","
+                    . $db->quote($record['content'], 'text') . ","
                     . $db->quote($record['ttl'], 'integer') . ","
                     . $db->quote(isset($record['prio']) ? $record['prio'] : 0, 'integer') . ")";
             $result = $db->exec($query2);


### PR DESCRIPTION
Ok some stuff is going wrong:

1. db data should _not_ be trimmed for the output. This confuses the user (e.g. "WTH didn't I just type XY?")
2. magicquotes is deprecated and no attention should be paid to it
3. addslashes/stripslashes were even under magicquotes era a very wrong approach
4.
```
$ grep -i -r -n -e "addslashes" .
```
(nothing = good)
5.
```
$ grep -i -r -n -e "stripslashes" .
./inc/record.inc.php:393:                $content = $db->quote(stripslashes('\"' . $record['content'] . '\"'), 'text');
./inc/record.inc.php:455:                $content = $db->quote(stripslashes('\"' . $content . '\"'), 'text');
./inc/templates.inc.php:312:                $content = $db->quote(stripslashes('\"' . $content . '\"'), 'text');
./inc/templates.inc.php:354:                $content = $db->quote(stripslashes('\"' . $record['content'] . '\"'), 'text');
./inc/templates.inc.php:463:                $content = $db->quote(stripslashes('\"' . $record['content'] . '\"'), 'text');
```
(not so good)
6. PDO->quote() is being used => all good!
7. With powerdns TXT should _not_ be put in between "quotes" but just plain as is, e.g. (in DB)
```
v=spf1 include:_spf.google.com ~all
```
instead of
```
"v=spf1 include:_spf.google.com ~all"
```
So what we actually need is a strict input validation (as seen for example on Amazons Route53) which would then warn the users "please remove the quotes" - but that is of course then the next todo.