### PR TITLE
don't edit_record for unchanged records, Issues #166, #234

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -51,25 +51,36 @@ if (isset($_POST['commit'])) {
     if (isset($_POST['record'])) {
         foreach ($_POST['record'] as $record) {
             $old_record_info = get_record_from_id($record['rid']);
-            $edit_record = edit_record($record);
-            if (false === $edit_record) {
-                $error = true;
-            } else {
-               $new_record_info = get_record_from_id($record["rid"]);
-               //Figure out if record was updated
-               unset($new_record_info["change_date"]);
-               unset($old_record_info["change_date"]);
-               if ($new_record_info != $old_record_info){
-                 //The record was changed, so log the edit_record operation
-                 log_info(sprintf('client_ip:%s user:%s operation:edit_record'
-                                  .' old_record_type:%s old_record:%s old_content:%s old_ttl:%s old_priority:%s'
-                                  .' record_type:%s record:%s content:%s ttl:%s priority:%s',
-                                  $_SERVER['REMOTE_ADDR'], $_SESSION["userlogin"],
-                              $old_record_info['type'], $old_record_info['name'],
-                              $old_record_info['content'], $old_record_info['ttl'], $old_record_info['prio'],
-                              $new_record_info['type'], $new_record_info['name'],
-                              $new_record_info['content'], $new_record_info['ttl'], $new_record_info['prio']));
-               }
+            unset($old_record_info["change_date"]);
+            $current_record = array(
+                "id" => (int)$record["rid"],
+                "domain_id" => (int)$record["zid"],
+                "name" => $record["name"],
+                "type" => $record["type"],
+                "content" => $record["content"],
+                "ttl" => (int)$record["ttl"],
+                "prio" => (int)$record["prio"]
+                );
+            if ($current_record != $old_record_info) {
+                $edit_record = edit_record($record);
+                if (false === $edit_record) {
+                    $error = true;
+                } else {
+                    $new_record_info = get_record_from_id($record["rid"]);
+                    //Figure out if record was updated
+                    unset($new_record_info["change_date"]);
+                    if ($new_record_info != $old_record_info){
+                        //The record was changed, so log the edit_record operation
+                        log_info(sprintf('client_ip:%s user:%s operation:edit_record'
+                            .' old_record_type:%s old_record:%s old_content:%s old_ttl:%s old_priority:%s'
+                            .' record_type:%s record:%s content:%s ttl:%s priority:%s',
+                            $_SERVER['REMOTE_ADDR'], $_SESSION["userlogin"],
+                            $old_record_info['type'], $old_record_info['name'],
+                            $old_record_info['content'], $old_record_info['ttl'], $old_record_info['prio'],
+                            $new_record_info['type'], $new_record_info['name'],
+                            $new_record_info['content'], $new_record_info['ttl'], $new_record_info['prio']));
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
Check if each record is changed, don't call edit_record() or log anything if not. Tested against 2.1.7.