### PR TITLE
Update records only if they have been changed

### DIFF
--- a/edit.php
+++ b/edit.php
@@ -32,6 +32,7 @@
  */
 require_once("inc/toolkit.inc.php");
 include_once("inc/header.inc.php");
+include_once("inc/RecordLog.class.php");
 
 global $pdnssec_use;
 
@@ -48,28 +49,28 @@ if ($zone_id == "-1") {
 
 if (isset($_POST['commit'])) {
     $error = false;
+    $one_record_changed = false;
+
     if (isset($_POST['record'])) {
         foreach ($_POST['record'] as $record) {
             $old_record_info = get_record_from_id($record['rid']);
+
+            // Check if a record changed and save the state
+            $log = new RecordLog();
+            $log->log_prior($record['rid']);
+            if (!$log->has_changed($record)) {
+                continue;
+            } else {
+                $one_record_changed = true;
+            }
+
             $edit_record = edit_record($record);
             if (false === $edit_record) {
                 $error = true;
             } else {
-               $new_record_info = get_record_from_id($record["rid"]);
-               //Figure out if record was updated
-               unset($new_record_info["change_date"]);
-               unset($old_record_info["change_date"]);
-               if ($new_record_info != $old_record_info){
-                 //The record was changed, so log the edit_record operation
-                 log_info(sprintf('client_ip:%s user:%s operation:edit_record'
-                                  .' old_record_type:%s old_record:%s old_content:%s old_ttl:%s old_priority:%s'
-                                  .' record_type:%s record:%s content:%s ttl:%s priority:%s',
-                                  $_SERVER['REMOTE_ADDR'], $_SESSION["userlogin"],
-                              $old_record_info['type'], $old_record_info['name'],
-                              $old_record_info['content'], $old_record_info['ttl'], $old_record_info['prio'],
-                              $new_record_info['type'], $new_record_info['name'],
-                              $new_record_info['content'], $new_record_info['ttl'], $new_record_info['prio']));
-               }
+                // Log the state after saving and write it to logging table
+                $log->log_after($record['rid']);
+                $log->write();
             }
         }
     }
@@ -78,7 +79,12 @@ if (isset($_POST['commit'])) {
 
     if (false === $error) {
         update_soa_serial($_GET['id']);
-        success(SUC_ZONE_UPD);
+
+        if ($one_record_changed) {
+            success(SUC_ZONE_UPD);
+        } else {
+            success(SUC_ZONE_NOCHANGE);
+        }
 
         if ($pdnssec_use) {
             if (dnssec_rectify_zone($_GET['id'])) {

--- a/inc/RecordLog.class.php
+++ b/inc/RecordLog.class.php
@@ -1,0 +1,64 @@
+<?php
+
+class RecordLog {
+
+    private $record_prior;
+    private $record_after;
+
+    private $record_changed = false;
+
+    public function log_prior($rid) {
+        $this->record_prior = $this->getRecord($rid);
+    }
+
+    public function log_after($rid) {
+        $this->record_after = $this->getRecord($rid);
+    }
+
+    private function getRecord($rid) {
+        return get_record_from_id($rid);
+    }
+
+    public function has_changed(array $record) {
+        // Arrays are assigned by copy.
+        // Copy arrays to avoid side effects caused by unset().
+        $record_copy = $record;
+        $record_prior_copy = $this->record_prior;
+
+        // Don't compare the 'change_date'
+        unset($record_copy["change_date"]);
+        unset($record_prior_copy["change_date"]);
+
+        // PowerDNS only searches for lowercase records
+        $record_copy['name'] = strtolower($record_copy['name']);
+        $record_prior_copy['name'] = strtolower($record_prior_copy['name']);
+
+        // Quotes are special for SPF and TXT
+        $type = $record_prior_copy['type'];
+        if ($type == "SPF" || $type == "TXT") {
+            $record_prior_copy['content'] = trim($record_prior_copy['content'], '"');
+            $record_copy['content'] = trim($record_copy['content'], '"');
+        }
+
+        // Make $record_copy and $record_prior_copy compatible
+        $record_copy['id'] = $record_copy['rid'];
+        $record_copy['domain_id'] = $record_copy['zid'];
+        unset($record_copy['zid']);
+        unset($record_copy['rid']);
+
+        // Do the comparison
+        $this->record_changed = ($record_copy != $record_prior_copy);
+        return $this->record_changed;
+    }
+
+    public function write() {
+        log_info(sprintf('client_ip:%s user:%s operation:edit_record'
+            . ' old_record_type:%s old_record:%s old_content:%s old_ttl:%s old_priority:%s'
+            . ' record_type:%s record:%s content:%s ttl:%s priority:%s',
+            $_SERVER['REMOTE_ADDR'], $_SESSION["userlogin"],
+            $this->record_prior['type'], $this->record_prior['name'],
+            $this->record_prior['content'], $this->record_prior['ttl'], $this->record_prior['prio'],
+            $this->record_after['type'], $this->record_after['name'],
+            $this->record_after['content'], $this->record_after['ttl'], $this->record_after['prio']));
+    }
+}

--- a/inc/error.inc.php
+++ b/inc/error.inc.php
@@ -130,6 +130,7 @@ define("SUC_ZONE_ADD", _('Zone has been added successfully.'));
 define("SUC_ZONE_DEL", _('Zone has been deleted successfully.'));
 define("SUC_ZONES_DEL", _('Zones have been deleted successfully.'));
 define("SUC_ZONE_UPD", _('Zone has been updated successfully.'));
+define("SUC_ZONE_NOCHANGE", _('Zone did not have any record changes.'));
 define("SUC_ZONES_UPD", _('Zones have been updated successfully.'));
 define("SUC_USER_UPD", _('The user has been updated successfully.'));
 define("SUC_USER_ADD", _('The user has been created successfully.'));


### PR DESCRIPTION
Prior, for every zone change, all records in the database were
updated. This patch improves upon that so that only changed records
in a zone are updated in the database.

The zone comment is still unchecked. A new serial will be generated,
even if there is no record change.

This fixes #234, #166.