### PR TITLE
Reporting of offending DNS record in error message and additional SRV error messages

### DIFF
--- a/inc/dns.inc.php
+++ b/inc/dns.inc.php
@@ -712,15 +712,15 @@ function is_valid_rr_srv_name(&$name) {
 
     $fields = explode('.', $name, 3);
     if (!preg_match('/^_[\w-]+$/i', $fields[0])) {
-        error(ERR_DNS_SRV_NAME);
+        error(ERR_DNS_SRV_NAME_SERVICE, $name);
         return false;
     }
     if (!preg_match('/^_[\w]+$/i', $fields[1])) {
-        error(ERR_DNS_SRV_NAME);
+        error(ERR_DNS_SRV_NAME_PROTO, $name);
         return false;
     }
     if (!is_valid_hostname_fqdn($fields[2], 0)) {
-        error(ERR_DNS_SRV_NAME);
+        error(ERR_DNS_SRV_NAME, $name);
         return false;
     }
     $name = join('.', $fields);
@@ -736,15 +736,15 @@ function is_valid_rr_srv_name(&$name) {
 function is_valid_rr_srv_content(&$content) {
     $fields = preg_split("/\s+/", trim($content), 3);
     if (!is_numeric($fields[0]) || $fields[0] < 0 || $fields[0] > 65535) {
-        error(ERR_DNS_SRV_WGHT);
+        error(ERR_DNS_SRV_WGHT, $name);
         return false;
     }
     if (!is_numeric($fields[1]) || $fields[1] < 0 || $fields[1] > 65535) {
-        error(ERR_DNS_SRV_PORT);
+        error(ERR_DNS_SRV_PORT, $name);
         return false;
     }
     if ($fields[2] == "" || ($fields[2] != "." && !is_valid_hostname_fqdn($fields[2], 0))) {
-        error(ERR_DNS_SRV_TRGT);
+        error(ERR_DNS_SRV_TRGT, $name);
         return false;
     }
     $content = join(' ', $fields);

--- a/inc/error.inc.php
+++ b/inc/error.inc.php
@@ -109,7 +109,9 @@ define("ERR_DNS_HN_TOO_LONG", _('The hostname is too long.'));
 define("ERR_DNS_INV_TLD", _('You are using an invalid top level domain.'));
 define("ERR_DNS_INV_TTL", _('Invalid value for TTL field. It should be numeric.'));
 define("ERR_DNS_INV_PRIO", _('Invalid value for prio field. It should be numeric.'));
-define("ERR_DNS_SRV_NAME", _('Invalid value for name field of SRV record.'));
+define("ERR_DNS_SRV_NAME_SERVICE", _('Invalid service value in name field of SRV record.'));
+define("ERR_DNS_SRV_NAME_PROTO", _('Invalid protocol value in name field of SRV record.'));
+define("ERR_DNS_SRV_NAME", _('Invalid FQDN value in name field of SRV record.'));
 define("ERR_DNS_SRV_WGHT", _('Invalid value for the priority field of the SRV record.'));
 define("ERR_DNS_SRV_PORT", _('Invalid value for the weight field of the SRV record.'));
 define("ERR_DNS_SRV_TRGT", _('Invalid SRV target.'));
@@ -155,9 +157,15 @@ define("SUC_EXEC_PDNSSEC_DEACTIVATE_ZONE_KEY", _('Zone key has been successfully
 /** Print error message (toolkit.inc)
  *
  * @param string $msg Error message
+ * @param string $name Offending DNS record name
  *
  * @return null
  */
-function error($msg) {
-    echo "     <div class=\"error\">Error: " . $msg . "</div>\n";
+function error($msg, $name = null) {
+        if ($name == null) {
+                echo "     <div class=\"error\">Error: " . $msg . "</div>\n";
+        } else {
+                echo "     <div class=\"error\">Error: " . $msg . " (Record: " . $name . ")</b></div>\n";
+        }
 }
+


### PR DESCRIPTION
1. Added new parameter to error function to allow reporting of offending DNS record to the error message so it's easier to locate the DNS record in the list. It will simply add the: "(Record: xyz.example.com) to the end of the error message. This is an optionial field and therefore won't break any calls to the error function not including the record name.

2. Added more granular error reporting for SRV records to distinguish between fields.

3. Show record name for SRV errors using above mentioned function
 