### PR TITLE
Update SOA change_date in autoserial mode when deleting record

### DIFF
--- a/delete_record.php
+++ b/delete_record.php
@@ -84,7 +84,7 @@ if ($record_id == "-1") {
             delete_record_zone_templ($record_id);
 
             // update serial after record deletion
-            update_soa_serial($zid);
+            update_soa_serial($zid, TRUE);
 
             if ($pdnssec_use) {
                 // do also rectify-zone


### PR DESCRIPTION
In SOA autoserial mode, serial value is determined as highest
change_date field of all records within the zone. When record
is deleted then dynamic serial value remains incorrectly the
same.

This patch increments change_date for SOA record in this case.
