### PR TITLE
dynamic_update: fix sql-query fetching records of zones

### DIFF
--- a/dynamic_update.php
+++ b/dynamic_update.php
@@ -204,7 +204,7 @@ $no_update_necessary = false;
 
 while ($zone = $zones_result->fetchRow()) {
     $zone_updated = false;
-    $name_query = "SELECT name, type, content FROM records WHERE domain_id='{$zone["domain_id"]}' and type = 'A' OR type = 'AAAA' ";
+    $name_query = "SELECT name, type, content FROM records WHERE domain_id='{$zone["domain_id"]}' and (type = 'A' OR type = 'AAAA') ";
     $result = $db->query($name_query);
 
     while ($record = $result->fetchRow()) {


### PR DESCRIPTION
Old version shows all versions with AAAA record of all domains owned by the user!

Type has to be queried always with domain_id.
so it has to be:
  domain_id AND ( type-A OR type-AAAA)