### PR TITLE
Add value for zone_templ_id

### DIFF
--- a/inc/record.inc.php
+++ b/inc/record.inc.php
@@ -338,8 +338,8 @@ function edit_zone_comment($zone_id, $comment) {
                 return false;
             }
         } else {
-            $query = "INSERT INTO zones (domain_id, owner, comment)
-				VALUES(" . $db->quote($zone_id, 'integer') . ",1," . $db->quote($comment, 'text') . ")";
+            $query = "INSERT INTO zones (domain_id, owner, comment, zone_templ_id)
+				VALUES(" . $db->quote($zone_id, 'integer') . ",1," . $db->quote($comment, 'text') . ",0)";
             $result = $db->query($query);
             if (PEAR::isError($result)) {
                 error($result->getMessage());


### PR DESCRIPTION
The absence of a value in zone_templ_id causes a non null error in Postgres and a general error that zone_templ_id doesn't have a default value in MySQl.

This was referenced in https://github.com/poweradmin/poweradmin/issues/308 and I've created the PR to fix