### PR TITLE
Fix for Missing SOA record when using bulk registration, and added some example text

### DIFF
--- a/add_zone_templ_record.php
+++ b/add_zone_templ_record.php
@@ -155,10 +155,10 @@ if (!(do_hook('verify_permission' , 'zone_master_add' )) || !$owner) {
     echo "     <tr>\n";
     echo "      <td colspan=\"6\"><br>&nbsp;&nbsp;&nbsp;&nbsp; * [ZONE] - " . _('substituted with current zone name') . "<br>";
     echo "&nbsp;&nbsp;&nbsp;&nbsp; * [SERIAL] - " . _('substituted with current date and 2 numbers') . " (YYYYMMDD + 00)\n <br>";
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; When using zone templates the SOA record will get added automatically to the new zone.<br>";
+    echo "&nbsp;&nbsp;&nbsp;&nbsp; When using zone templates the SOA record will get added automatically to the new zone.<br>";
     echo "&nbsp;&nbsp;&nbsp;&nbsp; Examples: to add a subdomain foo in a zonetemplate you would put foo.[ZONE] into the name field. <br>";
     echo "&nbsp;&nbsp;&nbsp;&nbsp; To add a wildcard record put *.[ZONE] in the name field.<br>";
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; Use just [ZONE] to have the domain itself return a value.</td>";
+    echo "&nbsp;&nbsp;&nbsp;&nbsp; Use just [ZONE] to have the domain itself return a value.</td>";
     echo "     </tr>\n";
     echo "      </table>\n";
     echo "      <br>\n";

--- a/add_zone_templ_record.php
+++ b/add_zone_templ_record.php
@@ -158,7 +158,7 @@ if (!(do_hook('verify_permission' , 'zone_master_add' )) || !$owner) {
 	echo "&nbsp;&nbsp;&nbsp;&nbsp; When using zone templates the SOA record will get added automatically to the new zone.<br>";
     echo "&nbsp;&nbsp;&nbsp;&nbsp; Examples: to add a subdomain foo in a zonetemplate you would put foo.[ZONE] into the name field. <br>";
     echo "&nbsp;&nbsp;&nbsp;&nbsp; To add a wildcard record put *.[ZONE] in the name field.<br>";
-	echo "&nbsp;&nbsp;&nbsp;&nbsp; Use just [ZONE] to have the domain itself return a value as well.</td>";
+	echo "&nbsp;&nbsp;&nbsp;&nbsp; Use just [ZONE] to have the domain itself return a value.</td>";
     echo "     </tr>\n";
     echo "      </table>\n";
     echo "      <br>\n";

--- a/add_zone_templ_record.php
+++ b/add_zone_templ_record.php
@@ -154,7 +154,11 @@ if (!(do_hook('verify_permission' , 'zone_master_add' )) || !$owner) {
     echo "     </tr>\n";
     echo "     <tr>\n";
     echo "      <td colspan=\"6\"><br>&nbsp;&nbsp;&nbsp;&nbsp; * [ZONE] - " . _('substituted with current zone name') . "<br>";
-    echo "&nbsp;&nbsp;&nbsp;&nbsp; * [SERIAL] - " . _('substituted with current date and 2 numbers') . " (YYYYMMDD + 00)</td>\n";
+    echo "&nbsp;&nbsp;&nbsp;&nbsp; * [SERIAL] - " . _('substituted with current date and 2 numbers') . " (YYYYMMDD + 00)\n <br>";
+	echo "&nbsp;&nbsp;&nbsp;&nbsp; When using zone templates the SOA record will get added automatically to the new zone.<br>";
+    echo "&nbsp;&nbsp;&nbsp;&nbsp; Examples: to add a subdomain foo in a zonetemplate you would put foo.[ZONE] into the name field. <br>";
+    echo "&nbsp;&nbsp;&nbsp;&nbsp; To add a wildcard record put *.[ZONE] in the name field.<br>";
+	echo "&nbsp;&nbsp;&nbsp;&nbsp; Use just [ZONE] to have the domain itself return a value as well.</td>";
     echo "     </tr>\n";
     echo "      </table>\n";
     echo "      <br>\n";

--- a/edit_zone_templ.php
+++ b/edit_zone_templ.php
@@ -155,7 +155,7 @@ if (!(do_hook('verify_permission' , 'zone_master_add' )) || !$owner) {
 			echo "&nbsp;&nbsp;&nbsp;&nbsp; When using zone templates the SOA record will get added automatically to the new zone.<br>";
             echo "&nbsp;&nbsp;&nbsp;&nbsp; Examples: to add a subdomain foo in a zonetemplate you would put foo.[ZONE] into the name field. <br>";
            	echo "&nbsp;&nbsp;&nbsp;&nbsp; To add a wildcard record put *.[ZONE] in the name field.<br>";
-			echo "&nbsp;&nbsp;&nbsp;&nbsp; Use just [ZONE] to have the domain itself return a value as well.</td>";
+			echo "&nbsp;&nbsp;&nbsp;&nbsp; Use just [ZONE] to have the domain itself return a value.</td>";
             echo "     </tr>\n";
             echo "     <tr>\n";
             echo "      <td colspan=\"6\"><br>Save as new template:</td>\n";

--- a/edit_zone_templ.php
+++ b/edit_zone_templ.php
@@ -154,7 +154,7 @@ if (!(do_hook('verify_permission' , 'zone_master_add' )) || !$owner) {
             echo "&nbsp;&nbsp;&nbsp;&nbsp; * [SERIAL] - " . _('substituted with current date and 2 numbers') . " (YYYYMMDD + 00)\n <br>";
             echo "&nbsp;&nbsp;&nbsp;&nbsp; When using zone templates the SOA record will get added automatically to the new zone.<br>";
             echo "&nbsp;&nbsp;&nbsp;&nbsp; Examples: to add a subdomain foo in a zonetemplate you would put foo.[ZONE] into the name field. <br>";
-           	echo "&nbsp;&nbsp;&nbsp;&nbsp; To add a wildcard record put *.[ZONE] in the name field.<br>";
+            echo "&nbsp;&nbsp;&nbsp;&nbsp; To add a wildcard record put *.[ZONE] in the name field.<br>";
             echo "&nbsp;&nbsp;&nbsp;&nbsp; Use just [ZONE] to have the domain itself return a value.</td>";
             echo "     </tr>\n";
             echo "     <tr>\n";

--- a/edit_zone_templ.php
+++ b/edit_zone_templ.php
@@ -144,14 +144,16 @@ if (!(do_hook('verify_permission' , 'zone_master_add' )) || !$owner) {
                 echo "     </tr>\n";
             }
             echo "     <tr>\n";
-            echo "      <td colspan=\"6\"><br><b>Hint:</b></td>\n";
+            echo "      <td colspan=\"6\"><br><b>HINT:</b></td>\n";
             echo "     </tr>\n";
             echo "     <tr>\n";
             echo "      <td colspan=\"6\">" . _('The following placeholders can be used in template records') . "</td>\n";
             echo "     </tr>\n";
             echo "     <tr>\n";
             echo "      <td colspan=\"6\"><br>&nbsp;&nbsp;&nbsp;&nbsp; * [ZONE] - " . _('substituted with current zone name') . "<br>";
-            echo "&nbsp;&nbsp;&nbsp;&nbsp; * [SERIAL] - " . _('substituted with current date and 2 numbers') . " (YYYYMMDD + 00)</td>\n";
+            echo "&nbsp;&nbsp;&nbsp;&nbsp; * [SERIAL] - " . _('substituted with current date and 2 numbers') . " (YYYYMMDD + 00)\n <br>";
+            echo "&nbsp;&nbsp;&nbsp;&nbsp; Example: to add a subdomain foo in a zonetemplate you would put foo.[ZONE] into the name field. <br>";
+            echo "&nbsp;&nbsp;&nbsp;&nbsp; When using zone templates the SOA record will get added automatically to the new zone.</td>";
             echo "     </tr>\n";
             echo "     <tr>\n";
             echo "      <td colspan=\"6\"><br>Save as new template:</td>\n";

--- a/edit_zone_templ.php
+++ b/edit_zone_templ.php
@@ -152,8 +152,10 @@ if (!(do_hook('verify_permission' , 'zone_master_add' )) || !$owner) {
             echo "     <tr>\n";
             echo "      <td colspan=\"6\"><br>&nbsp;&nbsp;&nbsp;&nbsp; * [ZONE] - " . _('substituted with current zone name') . "<br>";
             echo "&nbsp;&nbsp;&nbsp;&nbsp; * [SERIAL] - " . _('substituted with current date and 2 numbers') . " (YYYYMMDD + 00)\n <br>";
-            echo "&nbsp;&nbsp;&nbsp;&nbsp; Example: to add a subdomain foo in a zonetemplate you would put foo.[ZONE] into the name field. <br>";
-            echo "&nbsp;&nbsp;&nbsp;&nbsp; When using zone templates the SOA record will get added automatically to the new zone.</td>";
+			echo "&nbsp;&nbsp;&nbsp;&nbsp; When using zone templates the SOA record will get added automatically to the new zone.<br>";
+            echo "&nbsp;&nbsp;&nbsp;&nbsp; Examples: to add a subdomain foo in a zonetemplate you would put foo.[ZONE] into the name field. <br>";
+           	echo "&nbsp;&nbsp;&nbsp;&nbsp; To add a wildcard record put *.[ZONE] in the name field.<br>";
+			echo "&nbsp;&nbsp;&nbsp;&nbsp; Use just [ZONE] to have the domain itself return a value as well.</td>";
             echo "     </tr>\n";
             echo "     <tr>\n";
             echo "      <td colspan=\"6\"><br>Save as new template:</td>\n";

--- a/edit_zone_templ.php
+++ b/edit_zone_templ.php
@@ -152,10 +152,10 @@ if (!(do_hook('verify_permission' , 'zone_master_add' )) || !$owner) {
             echo "     <tr>\n";
             echo "      <td colspan=\"6\"><br>&nbsp;&nbsp;&nbsp;&nbsp; * [ZONE] - " . _('substituted with current zone name') . "<br>";
             echo "&nbsp;&nbsp;&nbsp;&nbsp; * [SERIAL] - " . _('substituted with current date and 2 numbers') . " (YYYYMMDD + 00)\n <br>";
-			echo "&nbsp;&nbsp;&nbsp;&nbsp; When using zone templates the SOA record will get added automatically to the new zone.<br>";
+            echo "&nbsp;&nbsp;&nbsp;&nbsp; When using zone templates the SOA record will get added automatically to the new zone.<br>";
             echo "&nbsp;&nbsp;&nbsp;&nbsp; Examples: to add a subdomain foo in a zonetemplate you would put foo.[ZONE] into the name field. <br>";
            	echo "&nbsp;&nbsp;&nbsp;&nbsp; To add a wildcard record put *.[ZONE] in the name field.<br>";
-			echo "&nbsp;&nbsp;&nbsp;&nbsp; Use just [ZONE] to have the domain itself return a value.</td>";
+            echo "&nbsp;&nbsp;&nbsp;&nbsp; Use just [ZONE] to have the domain itself return a value.</td>";
             echo "     </tr>\n";
             echo "     <tr>\n";
             echo "      <td colspan=\"6\"><br>Save as new template:</td>\n";

--- a/inc/record.inc.php
+++ b/inc/record.inc.php
@@ -732,7 +732,33 @@ function add_domain($domain, $owner, $type, $slave_master, $zone_template) {
                     return true;
                 } elseif ($domain_id && is_numeric($zone_template)) {
                     global $dns_ttl;
+# Addition -  Adds SOA record before we begin to add each template record 
 
+                    $ns1 = $dns_ns1;
+                    $hm = $dns_hostmaster;
+                    $ttl = $dns_ttl;
+
+                    set_timezone();
+
+                    $serial = date("Ymd");
+                    $serial .= "00";
+
+
+
+                    $query = "INSERT INTO records (domain_id, name, content, type, ttl, prio, change_date) VALUES ("
+                            . $db->quote($domain_id, 'integer') . ","
+                            . $db->quote($domain, 'text') . ","
+                            . $db->quote($ns1 . ' ' . $hm . ' ' . $serial . ' 28800 7200 604800 86400', 'text') . ","
+                            . $db->quote('SOA', 'text') . ","
+                            . $db->quote($ttl, 'integer') . ","
+                            . $db->quote(0, 'integer') . ","
+                            . $db->quote($now, 'integer') . ")";
+                    $response = $db->query($query);
+                    if (PEAR::isError($response)) {
+                        error($response->getMessage());
+                        return false;
+                    }
+#End of addition
                     $templ_records = get_zone_templ_records($zone_template);
                     if ($templ_records != -1) {
                         foreach ($templ_records as $r) {


### PR DESCRIPTION
Had this issue personally when setting up a new PDNS server recently using poweradmin for bulk import.

Changed inc/record.inc.php so it correctly adds the SOA when adding zones using bulk registration page and templates.

Added some example texts in edit_zone_templ.php and add_zone_templ_record.php

