### PR TITLE
Support for new LUA resource records of PowerDNS Authoriative Server version 4.2

### DIFF
--- a/add_record.php
+++ b/add_record.php
@@ -109,7 +109,7 @@ if ($zone_id == "-1") {
 
 /*
   Check and see if the user is the zone owner
-  Check the sone type and get the zone name
+  Check the zone type and get the zone name
  */
 $user_is_zone_owner = do_hook('verify_user_is_owner_zoneid', $zone_id);
 $zone_type = get_domain_type($zone_id);

--- a/inc/dns.inc.php
+++ b/inc/dns.inc.php
@@ -158,6 +158,9 @@ function validate_input($rid, $zid, $type, &$content, &$name, &$prio, &$ttl) {
       case 'KX': // TODO: implement validation
       break;
 
+      case "LUA": // TODO: implement validation.
+      break;
+
       case "LOC":
         if (!is_valid_loc($content)) {
           return false;

--- a/inc/toolkit.inc.php
+++ b/inc/toolkit.inc.php
@@ -339,6 +339,7 @@ $rtypes = array(
     'IPSECKEY',
     'KEY',
     'KX',
+    'LUA',
     'LOC',
     'MAILA',
     'MAILB',


### PR DESCRIPTION
PowerDNS Authoritative Server version 4.2, implements a new resource record to support "Dynamic Records". This change request implements support for the new 'LUA" resource records in PowerAdmin and would allow PowerAdmin to be used in dynamic environments such in "Global Server Load Balancing" environments.

Also a small typo I noticed, gets fixed as well.