### PR TITLE
Fix migration table field names in the field array

### DIFF
--- a/install/database-structure.inc.php
+++ b/install/database-structure.inc.php
@@ -452,7 +452,7 @@ $def_tables = array(
         'table_name' => 'migrations',
         'options' => array('type' => 'innodb'),
         'fields' => array(
-            'domain_id' => array
+            'version' => array
                 (
                 'notnull' => 1,
                 'length' => 255,
@@ -463,7 +463,7 @@ $def_tables = array(
                 'table' => 'migrations',
                 'flags' => 'not_null'
             ),
-            'record_id' => array
+            'apply_time' => array
                 (
                 'notnull' => 1,
                 'length' => 11,


### PR DESCRIPTION
The migrations table definition has incorrect field keys probably due to some copy-pasting. I almost missed them when manually fixing my database tables.