### PR TITLE
In SQL, SUBSTR and SUBSTRING are used depending on the db_type

### DIFF
--- a/inc/database.inc.php
+++ b/inc/database.inc.php
@@ -166,3 +166,14 @@ function dbConnect() {
     }
     return $db;
 }
+
+// SUBSTR/SUBSTRING selector
+function dbfunc_substr(){
+    global $db_type;
+    if( $db_type == "sqlite" ){
+        $result = "SUBSTR";
+    }else{
+        $result = "SUBSTRING";
+    }
+    return($result);
+}

--- a/inc/record.inc.php
+++ b/inc/record.inc.php
@@ -1236,9 +1236,9 @@ function get_zones($perm, $userid = 0, $letterstart = 'all', $rowstart = 0, $row
 				AND zones.owner = " . $db->quote($userid, 'integer');
         }
         if ($letterstart != 'all' && $letterstart != 1) {
-            $sql_add .=" AND substring(domains.name,1,1) = " . $db->quote($letterstart, 'text') . " ";
+            $sql_add .=" AND ".dbfunc_substr()."(domains.name,1,1) = " . $db->quote($letterstart, 'text') . " ";
         } elseif ($letterstart == 1) {
-            $sql_add .=" AND substring(domains.name,1,1) " . $sql_regexp . " '^[[:digit:]]'";
+            $sql_add .=" AND ".dbfunc_substr()."(domains.name,1,1) " . $sql_regexp . " '^[[:digit:]]'";
         }
     }
 
@@ -1327,7 +1327,7 @@ function zone_count_ng($perm, $letterstart = 'all') {
         if ($letterstart != 'all' && $letterstart != 1) {
             $sql_add .=" AND domains.name LIKE " . $db->quote($letterstart . "%", 'text') . " ";
         } elseif ($letterstart == 1) {
-            $sql_add .=" AND substring(domains.name,1,1) " . $sql_regexp . " '^[[:digit:]]'";
+            $sql_add .=" AND ".dbfunc_substr()."(domains.name,1,1) " . $sql_regexp . " '^[[:digit:]]'";
         }
 
 # XXX: do we really need this distinct directive as it's unsupported in sqlite)

--- a/inc/toolkit.inc.php
+++ b/inc/toolkit.inc.php
@@ -511,7 +511,7 @@ function show_letters($letterstart, $userid) {
     $allowed = zone_content_view_others($userid);
 
     $query = "SELECT
-			DISTINCT SUBSTRING(domains.name, 1, 1) AS letter
+			DISTINCT ".dbfunc_substr()."(domains.name, 1, 1) AS letter
 			FROM domains
 			LEFT JOIN zones ON domains.id = zones.domain_id
 			WHERE " . $allowed . " = 1


### PR DESCRIPTION
SQLite use SUBSTR(not SUBSTRING).
create SUBSTR/SUBSTRING selector. 
