### PR TITLE
Solve bug: "continue" targeting switch is equivalent to "break"

### DIFF
--- a/inc/record.inc.php
+++ b/inc/record.inc.php
@@ -1500,8 +1500,6 @@ function order_domain_results($domains, $sortby) {
                 $ns[] = $domain;
                 unset($domains[$key]);
                 break;
-            default:
-                continue;
         }
     }
 


### PR DESCRIPTION
Hi,

I face to a warning in **PowerAdmin**.

```
Warning: "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in /usr/local/www/nginx-dist/pdns/inc/record.inc.php on line 1504
```

![demo](https://user-images.githubusercontent.com/2658040/90630711-c9cd2e80-e236-11ea-9f1f-ce6dde34a752.jpg)

issue: https://github.com/poweradmin/poweradmin/issues/382

Regards,
Max

