### PR TITLE
Incompatibility in PHP version 8.0

### DIFF
--- a/inc/PDOCommon.class.php
+++ b/inc/PDOCommon.class.php
@@ -142,7 +142,7 @@ class PDOCommon extends PDO {
      * @param string $str
      * @return \PDOStatementCommon
      */
-    public function query($str) {
+    public function query($str, ?int $fetchMode = null, mixed ...$fetchModeArgs) {
         // check if limit has been specified. if so, modify the query
         if (!empty($this->limit)) {
             $str .= " LIMIT " . $this->limit;

--- a/inc/PDOLayer.php
+++ b/inc/PDOLayer.php
@@ -125,7 +125,7 @@ class PDOLayer extends PDOCommon {
      * @param string $str SQL query
      * @return PDOStatement
      */
-    public function query($str) {
+    public function query($str, ?int $fetchMode = null, mixed ...$fetchModeArgs) {
         if ($this->debug) {
             $this->queries[] = $str;
         }


### PR DESCRIPTION
Hi there,

I encountered problems with using this script in PHP 8 that were resolved with these changes.

PDOCommon.class.php file:
```
Fatal error: Declaration of PDOCommon::query($str) must be compatible with PDO::query(string $query, ?int $fetchMode = null, mixed ...$fetchModeArgs) in /usr/local/www/nginx-dist/powerdns/inc/PDOCommon.class.php on line 145
```

PDOLayer.php file:
```
Fatal error: Declaration of PDOLayer::query($str) must be compatible with PDOCommon::query($str, ?int $fetchMode = null, mixed ...$fetchModeArgs) in /usr/local/www/nginx-dist/powerdns/inc/PDOLayer.php on line 128
```

Refer: https://github.com/poweradmin/poweradmin/issues/390

Regards,
Max