### PR TITLE
Added missing import of Poweradmin\Validation

### DIFF
--- a/delete_record.php
+++ b/delete_record.php
@@ -31,6 +31,7 @@
 
 use Poweradmin\DnsRecord;
 use Poweradmin\Dnssec;
+use Poweradmin\Validation;
 use Poweradmin\Syslog;
 
 require_once 'inc/toolkit.inc.php';


### PR DESCRIPTION
Fixes a fatal

```
PHP message: PHP Fatal error:  Uncaught Error: Class 'Validation' not found in /path/to/poweradmin/delete_record.php:44
```