### PR TITLE
Make sure user can view any zone content if allowed

### DIFF
--- a/inc/pagination.inc.php
+++ b/inc/pagination.inc.php
@@ -122,11 +122,15 @@ function show_letters($letterstart, $userid) {
 
     $char_range = array_merge(range('a', 'z'), array('_'));
 
+    $allowed = zone_content_view_others($userid);
+
     $query = "SELECT
 			DISTINCT ".dbfunc_substr()."(domains.name, 1, 1) AS letter
 			FROM domains
 			LEFT JOIN zones ON domains.id = zones.domain_id
-			WHERE zones.owner = " . $userid;
+			WHERE " . $allowed . " = 1
+			OR zones.owner = " . $userid . "
+			ORDER BY 1";
     $db->setLimit(36);
 
     $available_chars = array();


### PR DESCRIPTION
https://github.com/poweradmin/poweradmin/issues/435

After moving out the pagination from toolkit to it's own pagination this issue started. 

Found out after there was no longer a callback to the zone_content_view_others function. I've reimplemented it and tested it and this will solve the issue. 