### PR TITLE
Some DNSSEC fixes

### DIFF
--- a/dnssec_add_key.php
+++ b/dnssec_add_key.php
@@ -61,7 +61,7 @@ $key_type = "";
 if (isset($_POST['key_type'])) {
     $key_type = $_POST['key_type'];
 
-    if ($key_type != 'ksk' && $key_type != 'zsk' && $key_type != 'csk') {
+    if ($key_type != 'ksk' && $key_type != 'zsk') {
         error(ERR_INV_INPUT);
         include_once("inc/footer.inc.php");
         exit;
@@ -110,7 +110,6 @@ echo "        <td>" . _('Key type') . "</td>\n";
 echo "        <td>\n";
 echo "         <select class=\"form-select form-select-sm\" name=\"key_type\">\n";
 echo "          <option value=\"\"></option>\n";
-echo "		<option value=\"csk\">CSK</option>\n";
 echo "          <option value=\"ksk\">KSK</option>\n";
 echo "          <option value=\"zsk\">ZSK</option>\n";
 echo "         </select>\n";

--- a/dnssec_edit_key.php
+++ b/dnssec_edit_key.php
@@ -89,10 +89,12 @@ if ($confirm == '1') {
     if ($key_info[5]) {
         if (Dnssec::dnssec_deactivate_zone_key($domain_name, $key_id)) {
             success(SUC_EXEC_PDNSSEC_DEACTIVATE_ZONE_KEY);
+	echo "<p class=\"pt-3\"><a href='dnssec.php?id=" . $zone_id . "'>Back to DNSSEC " . $domain_name . "</a></p>";
         }
     } else {
         if (Dnssec::dnssec_activate_zone_key($domain_name, $key_id)) {
             success(SUC_EXEC_PDNSSEC_ACTIVATE_ZONE_KEY);
+	echo "<p class=\"pt-3\"><a href='dnssec.php?id=" . $zone_id . "'>Back to DNSSEC " . $domain_name . "</a></p>";
         }
     }
 } else {

--- a/lib/Dnssec.php
+++ b/lib/Dnssec.php
@@ -60,7 +60,7 @@ class Dnssec
      *
      * @return array Array with output from command execution and error code
      */
-    public static function dnssec_call_pdnssec($command, $args): array
+    public static function dnssec_call_pdnssec($command, $domain, $args = Array ()): array
     {
         global $pdnssec_command, $pdnssec_debug;
         $output = '';
@@ -70,10 +70,19 @@ class Dnssec
             return array($output, $return_code);
         }
 
+	if (!is_array ($args)) {
+	    return array('ERROR: internal error, input not Array ()', $return_code);
+	} else {
+		foreach ($args as $k => $v) {
+			$args [$k] = escapeshellarg ($v);
+		}
+		$args = join (' ', $args);
+	}
+
         $full_command = join(' ', array(
                 escapeshellcmd($pdnssec_command),
                 $command,
-                escapeshellarg($args),
+                escapeshellarg($domain).' '.$args,
                 '2>&1')
         );
 
@@ -409,7 +418,7 @@ class Dnssec
      */
     public static function dnssec_activate_zone_key($domain_name, $key_id): bool
     {
-        $call_result = self::dnssec_call_pdnssec('activate-zone-key', join(" ", array($domain_name, $key_id)));
+        $call_result = self::dnssec_call_pdnssec('activate-zone-key', $domain_name, array($key_id));
         $return_code = $call_result[1];
 
         if ($return_code != 0) {
@@ -432,7 +441,7 @@ class Dnssec
      */
     public static function dnssec_deactivate_zone_key($domain_name, $key_id): bool
     {
-        $call_result = self::dnssec_call_pdnssec('deactivate-zone-key', join(" ", array($domain_name, $key_id)));
+        $call_result = self::dnssec_call_pdnssec('deactivate-zone-key', $domain_name, array($key_id));
         $return_code = $call_result[1];
 
         if ($return_code != 0) {
@@ -495,7 +504,7 @@ class Dnssec
      */
     public static function dnssec_add_zone_key($domain_name, $key_type, $bits, $algorithm): bool
     {
-        $call_result = self::dnssec_call_pdnssec('add-zone-key', join(" ", array($domain_name, $key_type, $bits, "inactive", $algorithm)));
+        $call_result = self::dnssec_call_pdnssec('add-zone-key', $domain_name, array($key_type, $bits, "inactive", $algorithm));
         $return_code = $call_result[1];
 
         if ($return_code != 0) {
@@ -518,7 +527,7 @@ class Dnssec
      */
     public static function dnssec_remove_zone_key($domain_name, $key_id): bool
     {
-        $call_result = self::dnssec_call_pdnssec('remove-zone-key', join(" ", array($domain_name, $key_id)));
+        $call_result = self::dnssec_call_pdnssec('remove-zone-key', $domain_name, array($key_id));
         $return_code = $call_result[1];
 
         if ($return_code != 0) {


### PR DESCRIPTION
- add 'Back to DNSSEC'-link for edit key
- adding CSK type isn't supported by PowerDNS: https://doc.powerdns.com/authoritative/manpages/pdnsutil.1.html#dnssec-related-commands
- individually escape the shell arguments when calling dnssec_call_pdnssec, some commands failed without this change