### PR TITLE
add quotes to reverse_search_string

### DIFF
--- a/lib/Application/Query/RecordSearch.php
+++ b/lib/Application/Query/RecordSearch.php
@@ -88,7 +88,7 @@ class RecordSearch extends BaseSearch
             LEFT JOIN users u on z.owner = u.id
             WHERE
                 (records.name LIKE ' . $this->db->quote($search_string, 'text') . ' OR records.content LIKE ' . $this->db->quote($search_string, 'text') .
-            ($reverse ? ' OR records.name LIKE ' . $this->db->quote($reverse_search_string, 'text') . ' OR records.content LIKE ' . $reverse_search_string : '') . ')' .
+            ($reverse ? ' OR records.name LIKE ' . $this->db->quote($reverse_search_string, 'text') . ' OR records.content LIKE ' . $this->db->quote($reverse_search_string, 'text') : '') . ')' .
             ($permission_view == 'own' ? 'AND z.owner = ' . $this->db->quote($_SESSION['userid'], 'integer') : '') .
             ($iface_search_group_records ? ' GROUP BY records.name, records.content ' : '') .
             ' ORDER BY ' . $sort_records_by .
@@ -146,7 +146,7 @@ class RecordSearch extends BaseSearch
             LEFT JOIN users u on z.owner = u.id
             WHERE
                 (records.name LIKE ' . $this->db->quote($search_string, 'text') . ' OR records.content LIKE ' . $this->db->quote($search_string, 'text') .
-            ($reverse ? ' OR records.name LIKE ' . $reverse_search_string . ' OR records.content LIKE ' . $reverse_search_string : '') . ')' .
+            ($reverse ? ' OR records.name LIKE ' . $this->db->quote($reverse_search_string, 'text') . ' OR records.content LIKE ' . $this->db->quote($reverse_search_string, 'text') : '') . ')' .
             ($permission_view == 'own' ? 'AND z.owner = ' . $this->db->quote($_SESSION['userid'], 'integer') : '') .
             ($iface_search_group_records ? ' GROUP BY records.name, records.content ' : '');
 

--- a/lib/Application/Query/ZoneSearch.php
+++ b/lib/Application/Query/ZoneSearch.php
@@ -160,7 +160,7 @@ class ZoneSearch extends BaseSearch
             LEFT JOIN (SELECT COUNT(domain_id) AS count_records, domain_id FROM records WHERE type IS NOT NULL GROUP BY domain_id) record_count ON record_count.domain_id=domains.id
             WHERE
                 (domains.name LIKE ' . $this->db->quote($search_string, 'text') .
-            ($reverse ? ' OR domains.name LIKE ' . $reverse_search_string : '') . ') ' .
+            ($reverse ? ' OR domains.name LIKE ' . $this->db->quote($reverse_search_string, 'text') : '') . ') ' .
             ($permission_view == 'own' ? ' AND z.owner = ' . $this->db->quote($_SESSION['userid'], 'integer') : '');
 
         return (int)$this->db->queryOne($zonesQuery);


### PR DESCRIPTION
RecordSearch.php and ZoneSearch.php are not using the quote function for reverse_search_string, leading to errors when searching for an IP with the reverse option enabled.

```
An error occurred while executing the SQL statement. Please contact an Administrator and report the problem.
The following query generated an error:

            SELECT
                COUNT(*)
            FROM
                domains
            
LEFT 
JOIN zones z on domains.id = z.domain_id
            
LEFT 
JOIN users u on z.owner = u.id
            
LEFT 
JOIN (
SELECT COUNT(domain_id) AS count_records,
 domain_id 
FROM records 
WHERE type IS NOT NULL 
GROUP BY domain_id) record_count
 ON record_count.domain_id=domains.id
            WHERE
                (domains.name LIKE '%xxx.xxx.xxx.xxx%' 
OR domains.name LIKE %xxx.xxx.xxx.xxx%) 

SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '%xxx.xxx.xxx.xxx%)' at line 9
```