### PR TITLE
DnsRecord.php content check

### DIFF
--- a/lib/DnsRecord.php
+++ b/lib/DnsRecord.php
@@ -1251,7 +1251,7 @@ class DnsRecord
     {
         $result = $db->queryRow("SELECT * FROM records WHERE id=" . $db->quote($id, 'integer') . " AND type IS NOT NULL");
         if ($result) {
-            if ($result["type"] == "" || $result["content"] == "") {
+            if ($result["type"] == "") {
                 return -1;
             }
 
@@ -1793,9 +1793,9 @@ class DnsRecord
      *
      * Set timezone to configured tz or UTC it not set
      *
-     * @return null
+     * @return void
      */
-    public function set_timezone()
+    public function set_timezone(): void
     {
         $timezone = $this->config->get('timezone');
 


### PR DESCRIPTION
the function get_record_from_id of DnsRecord.php checked for an empty content and returns -1.

Which results in the following error:

> Fatal error: Uncaught Error: Cannot use a scalar value as an array in /var/www/html/lib/RecordLog.php:44 Stack trace: #0 /var/www/html/edit.php(266): Poweradmin\RecordLog->log_prior('<removed>', '<removed>') #1 /var/www/html/edit.php(70): EditController->saveRecords(<removed>, true, '<removed>') #2 /var/www/html/edit.php(338): EditController->run() #3 {main} thrown in /var/www/html/lib/RecordLog.php on line 44

Currently you cannot update a Zone, that has multiple empty content fields - even when you fill them all. (For example, when the zone was created by a zone template, that has empty contents for multiple records).

This pull-request removes the content check.

---

Unrelated to the issue above, the set_timezone function returns nothing, so it was changed to do so.