### PR TITLE
Fix case of DNSSEC Controller so router can find it

### DIFF
--- a/lib/Application/Controller/DnssecController.php
+++ b/lib/Application/Controller/DnssecController.php
@@ -41,7 +41,7 @@ use Poweradmin\Permission;
 use Poweradmin\Validation;
 use Poweradmin\ZoneTemplate;
 
-class DnsSecController extends BaseController
+class DnssecController extends BaseController
 {
 
     public function run(): void


### PR DESCRIPTION
getControllerClassName calls ucwords() to convert a page name to a class name. This commit renames the "DnsSecController" to "DnssecController" to fit the required convention.