### PR TITLE
Add LDAP change pass exception

### DIFF
--- a/lib/LegacyUsers.php
+++ b/lib/LegacyUsers.php
@@ -421,10 +421,10 @@ class LegacyUsers
             return false;
         }
 
-        $query = "SELECT id, password FROM users WHERE username = {$db->quote($_SESSION ["userlogin"], 'text')}";
-        
+        $query = "SELECT id, password, use_ldap FROM users WHERE username = {$db->quote($_SESSION ["userlogin"], 'text')}";
         $response = $db->queryRow($query);
-        if ($response['password'] == 'LDAP_USER') {
+        
+        if ($response['use_ldap']) {
             $error = new ErrorMessage(_('You can not change your password as LDAP user.'));
             $errorPresenter = new ErrorPresenter();
             $errorPresenter->present($error);

--- a/lib/LegacyUsers.php
+++ b/lib/LegacyUsers.php
@@ -422,7 +422,15 @@ class LegacyUsers
         }
 
         $query = "SELECT id, password FROM users WHERE username = {$db->quote($_SESSION ["userlogin"], 'text')}";
+        
         $response = $db->queryRow($query);
+        if ($response['password'] == 'LDAP_USER') {
+            $error = new ErrorMessage(_('You can not change your password as LDAP user.'));
+            $errorPresenter = new ErrorPresenter();
+            $errorPresenter->present($error);
+
+            return false;
+        }
 
         $config = new LegacyConfiguration();
         $userAuthService = new UserAuthenticationService(


### PR DESCRIPTION
Hello, small fix to prevent throwing exception_(placed it below)_ when user authenticating via LDAP and password data about him was storage as 'LDAP_USER'

```
[Fri Apr 26 13:43:57 2024] 192.168.1.5:62652 [200]: POST /index.php?page=change_password - Uncaught InvalidArgumentException: Unable to determine hash algorithm in /app/lib/Application/Service/UserAuthenticationService.php:176
Stack trace:
#0 /app/lib/Application/Service/UserAuthenticationService.php(103): Poweradmin\Application\Service\UserAuthenticationService->identifyHashAlgorithm('LDAP_USER')
#1 /app/lib/LegacyUsers.php(433): Poweradmin\Application\Service\UserAuthenticationService->verifyPassword('User', 'LDAP_USER')
#2 /app/lib/Application/Controller/ChangePasswordController.php(68): Poweradmin\LegacyUsers::change_user_pass(Object(Poweradmin\PDOLayer), Array)
#3 /app/lib/Application/Routing/BasicRouter.php(108): Poweradmin\Application\Controller\ChangePasswordController->run()
#4 /app/index.php(76): Poweradmin\Application\Routing\BasicRouter->process()
#5 {main}
  thrown in /app/lib/Application/Service/UserAuthenticationService.php on line 176
```
And its look's like:
![image](https://github.com/poweradmin/poweradmin/assets/98015581/05a72ccc-3436-4682-a574-8c11e9fecbae)

P.S.
I dont know how to change locales data,

