### PR TITLE
Change "input" fileds of rdata to "textarea" and fix searching bug with PostgreSQL

### DIFF
--- a/lib/Application/Query/RecordSearch.php
+++ b/lib/Application/Query/RecordSearch.php
@@ -93,7 +93,7 @@ class RecordSearch extends BaseSearch
                 ($records_table.name LIKE " . $this->db->quote($search_string, 'text') . " OR $records_table.content LIKE " . $this->db->quote($search_string, 'text') .
             ($reverse ? " OR $records_table.name LIKE " . $this->db->quote($reverse_search_string, 'text') . " OR $records_table.content LIKE " . $this->db->quote($reverse_search_string, 'text') : '') . ')' .
             ($permission_view == 'own' ? 'AND z.owner = ' . $this->db->quote($_SESSION['userid'], 'integer') : '') .
-            ($iface_search_group_records ? " GROUP BY $records_table.name, $records_table.content " : '') .
+            ($iface_search_group_records ? " GROUP BY $records_table.name, $records_table.content, $records_table.id, zone_id, user_id" : '') .
             ' ORDER BY ' . $sort_records_by .
             ' LIMIT ' . $iface_rowamount . ' OFFSET ' . $offset;
 

--- a/lib/LegacyUsers.php
+++ b/lib/LegacyUsers.php
@@ -421,10 +421,10 @@ class LegacyUsers
             return false;
         }
 
-        $query = "SELECT id, password FROM users WHERE username = {$db->quote($_SESSION ["userlogin"], 'text')}";
-        
+        $query = "SELECT id, password, use_ldap FROM users WHERE username = {$db->quote($_SESSION ["userlogin"], 'text')}";
         $response = $db->queryRow($query);
-        if ($response['password'] == 'LDAP_USER') {
+        
+        if ($response['use_ldap']) {
             $error = new ErrorMessage(_('You can not change your password as LDAP user.'));
             $errorPresenter = new ErrorPresenter();
             $errorPresenter->present($error);

--- a/lib/LegacyUsers.php
+++ b/lib/LegacyUsers.php
@@ -422,7 +422,15 @@ class LegacyUsers
         }
 
         $query = "SELECT id, password FROM users WHERE username = {$db->quote($_SESSION ["userlogin"], 'text')}";
+        
         $response = $db->queryRow($query);
+        if ($response['password'] == 'LDAP_USER') {
+            $error = new ErrorMessage(_('You can not change your password as LDAP user.'));
+            $errorPresenter = new ErrorPresenter();
+            $errorPresenter->present($error);
+
+            return false;
+        }
 
         $config = new LegacyConfiguration();
         $userAuthService = new UserAuthenticationService(

--- a/templates/add_record.html
+++ b/templates/add_record.html
@@ -48,7 +48,7 @@
                     {% endfor %}
                 </select>
             </td>
-            <td><input class="form-control form-control-sm" type="text" name="content" value="{{ content }}" required>
+            <td><textarea class="form-control form-control-sm" name="content" style="height: 1em;" required>{{ content }}</textarea>
                 <div class="invalid-feedback">{% trans %}Provide content{% endtrans %}</div>
             </td>
             <td class="col-sm-1"><input class="form-control form-control-sm" type="number" name="prio"

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -91,8 +91,7 @@
                     {% endif %}
                 </select>
             </td>
-            <td><input class="form-control form-control-sm" type="text"
-                       name="record[{{ r['id'] }}][content]" value="{{ r['content'] }}"></td>
+            <td><textarea class="form-control form-control-sm" name="record[{{ r['id'] }}][content]" style="height: 1em;">{{ r['content'] }}</textarea></td>
             <td class="col-sm-1"><input class="form-control form-control-sm" type="number"
                                         id="priority_field_{{ r['id'] }}" name="record[{{ r['id'] }}][prio]"
                                         min="0" max="65535" pattern="[0-9]*" value="{{ r['prio'] }}"></td>
@@ -195,7 +194,7 @@
                     {% endfor %}
                 </select>
             </td>
-            <td><input class="form-control form-control-sm" type="text" name="content" value="" required>
+            <td><textarea class="form-control form-control-sm" name="content" style="height: 1em;" required></textarea>
                 <div class="invalid-feedback">{% trans %}Provide content{% endtrans %}</div>
             </td>
             <td class="col-sm-1"><input class="form-control form-control-sm" type="number" name="prio" value="0"

--- a/templates/edit_record.html
+++ b/templates/edit_record.html
@@ -67,8 +67,7 @@
                     {% endif %}
                 </select>
             </td>
-            <td><input class="form-control form-control-sm" type="text" name="content" value="{{ record['content'] }}"
-                       required>
+            <td><textarea class="form-control form-control-sm" name="content" style="height: 1em;" required>{{ record['content'] }}</textarea>
                 <div class="invalid-feedback">{% trans %}Provide content{% endtrans %}</div>
             </td>
             <td><input class="form-control form-control-sm" type="number" name="prio" min="0" max="65535"


### PR DESCRIPTION
Hello

**First.**
Change type of rdata fields of records from "input" to "textarea" for cases of big rdata _(like DKIM, LUA and etc.)_ 
Now how its looks like:
- Zone page:
![image](https://github.com/poweradmin/poweradmin/assets/98015581/eee0ebd9-fa55-4930-a08a-59165018cf41)
- Edit Record page:
![image](https://github.com/poweradmin/poweradmin/assets/98015581/35d6d303-9da4-45b4-9485-3e39fe4593c1)
- Add Record page:
![image](https://github.com/poweradmin/poweradmin/assets/98015581/f5f67aa7-a039-4cac-8f56-c13f06945a31)


[It is supported by all popular _(even IE)_ browsers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea#browser_compatibility)

**Second.**

Fix bug with searching when using PostgreSQL the one don't like grouping data with excluded primary keys.
The bug:
```
n error occurred while executing the SQL statement. Please contact an Administrator and report the problem.
The following query generated an error:
            SELECT
                records.id,

                records.domain_id,

                records.name,

                records.type,

                records.content,

                records.ttl,

                records.prio,

                z.id as zone_id,

                z.owner,

                u.id as user_id,

                u.fullname
            FROM
                records
            
LEFT 
JOIN zones z on records.domain_id = z.domain_id
            
LEFT 
JOIN users u on z.owner = u.id
            WHERE
                (records.name LIKE '%tinirog.ru%' 
OR records.content LIKE '%tinirog.ru%') 
GROUP BY records.name,
 records.content  
ORDER BY name 
LIMIT 10 OFFSET 0

SQLSTATE[42803]: Grouping error: 7 ERROR:  column "records.id" must appear in the GROUP BY clause or be used in an aggregate function
LINE 3:                 records.id,
                        ^
```



