### PR TITLE
Restore trailing dot on the hostname in the SOA to prevent check-zone…

### DIFF
--- a/lib/Dns.php
+++ b/lib/Dns.php
@@ -765,7 +765,8 @@ class Dns
             if (!$this->is_valid_hostname_fqdn($fields[0], 0) || preg_match('/\.arpa\.?$/', $fields[0])) {
                 return false;
             }
-            $final_soa = $fields[0];
+	    // is_valid_hostname_fqdn strips the trailing dot which is required for a properly formed SOA, add it back
+            $final_soa = $fields[0] . ".";
 
             $addr_input = $fields[1] ?? $dns_hostmaster;
             if (!str_contains($addr_input, "@")) {


### PR DESCRIPTION
… warnings about inconsistency

A properly formed SOA record has a trailing dot after the hostname of the first nameserver that is specified in the first field, i.e.

"ns0.mynameserver.com." 

the function is_valid_hostname_fqdn *strips* this trailing dot from the hostname (even though I would expect an "is_valid" function not to modify anything, really).

This causes relatively harmless but still annoying errors when running check_zone about the SOA record value (without a trailing dot) and interpreted value (where powerdns has interpreted it as if it *DID* have a trailing dot) differing.

Other elements of the codebase currently rely on is_valid_hostname_fqdn stripping the trailing dot, however, as powerdns whinges about some records (e.g. NS) ending in a trailing dot.

This change is the minimum amount of change required to make SOA records properly formed, but later as part of the ongoing refactoring, is_valid_hostname_fqdn probably should have the "trailing dot stripping" behaviour removed, and the stripping of trailing dots should instead be made explicit when processing records that contain hostnames which PowerDNS does not want to have trailing dots.