### PR TITLE
Fix deprecated warnings caused by PHP 8.4

### DIFF
--- a/lib/Application/Service/LoggingService.php
+++ b/lib/Application/Service/LoggingService.php
@@ -29,7 +29,7 @@ abstract class LoggingService
     protected Logger $logger;
     private ?string $className;
 
-    public function __construct(Logger $logger, string $className = null)
+    public function __construct(Logger $logger, ?string $className = null)
     {
         $this->logger = $logger;
         $this->className = $className;

--- a/lib/Domain/Model/ZoneTemplate.php
+++ b/lib/Domain/Model/ZoneTemplate.php
@@ -425,7 +425,7 @@ class ZoneTemplate
      *
      * @return boolean true on success, false otherwise
      */
-    public static function add_zone_templ_save_as($db, string $template_name, string $description, int $userid, array $records, string $domain = null): bool
+    public static function add_zone_templ_save_as($db, string $template_name, string $description, int $userid, array $records, ?string $domain = null): bool
     {
         if (!(UserManager::verify_permission($db, 'zone_master_add'))) {
             $error = new ErrorMessage(_("You do not have the permission to add a zone template."));
@@ -562,7 +562,7 @@ class ZoneTemplate
      *
      * @return bool number of matching templates
      */
-    public static function zone_templ_name_exists($db, string $zone_templ_name, int $zone_templ_id = null): bool
+    public static function zone_templ_name_exists($db, ?string $zone_templ_name, int $zone_templ_id = null): bool
     {
         $sql_add = '';
         if ($zone_templ_id) {

--- a/lib/Domain/Model/ZoneTemplate.php
+++ b/lib/Domain/Model/ZoneTemplate.php
@@ -562,7 +562,7 @@ class ZoneTemplate
      *
      * @return bool number of matching templates
      */
-    public static function zone_templ_name_exists($db, ?string $zone_templ_name, int $zone_templ_id = null): bool
+    public static function zone_templ_name_exists($db, ?string $zone_templ_name, ?int $zone_templ_id = null): bool
     {
         $sql_add = '';
         if ($zone_templ_id) {

--- a/lib/Domain/Model/ZoneTemplate.php
+++ b/lib/Domain/Model/ZoneTemplate.php
@@ -562,7 +562,7 @@ class ZoneTemplate
      *
      * @return bool number of matching templates
      */
-    public static function zone_templ_name_exists($db, ?string $zone_templ_name, ?int $zone_templ_id = null): bool
+    public static function zone_templ_name_exists($db, string $zone_templ_name, ?int $zone_templ_id = null): bool
     {
         $sql_add = '';
         if ($zone_templ_id) {

--- a/lib/Infrastructure/Service/ThemeManager.php
+++ b/lib/Infrastructure/Service/ThemeManager.php
@@ -33,7 +33,7 @@ class ThemeManager
     private array $availableThemes;
     private string $styleDir;
 
-    public function __construct(string $style = null, string $style_dir = null)
+    public function __construct(?string $style = null, ?string $style_dir = null)
     {
         $this->styleDir = $style_dir ?? self::DEFAULT_STYLE_DIR;
         $this->availableThemes = $this->getAvailableThemes();


### PR DESCRIPTION
This commit fixes the following warnings thrown by PHP 8.4.0 r1 while keeping $className defined as null.

```
Deprecated: Poweradmin\Application\Service\LoggingService::__construct(): Implicitly marking parameter $className as nullable is deprecated, the explicit nullable type must be used instead in /net/www/lib/Application/Service/LoggingService.php on line 32

Warning: Cannot modify header information - headers already sent by (output started at /net/www/lib/Application/Service/LoggingService.php:32) in /net/www/lib/Infrastructure/Service/RedirectService.php on line 27
```

```
Deprecated: Poweradmin\Infrastructure\Service\ThemeManager::__construct(): Implicitly marking parameter $style as nullable is deprecated, the explicit nullable type must be used instead in /net/www/lib/Infrastructure/Service/ThemeManager.php on line 36

Deprecated: Poweradmin\Infrastructure\Service\ThemeManager::__construct(): Implicitly marking parameter $style_dir as nullable is deprecated, the explicit nullable type must be used instead in /net/www/lib/Infrastructure/Service/ThemeManager.php on line 36
```

