### PR TITLE
Fixed typo that duplicates the translation string

### DIFF
--- a/locale/i18n-template-php.pot
+++ b/locale/i18n-template-php.pot
@@ -1378,6 +1378,7 @@ msgid "Examples:"
 msgstr ""
 
 #: templates/add_zone_templ_record.html:76
+#: templates/edit_zone_templ.html:92
 msgid ""
 "To add a subdomain foo in a zone template you would put foo.[ZONE] into the "
 "name field."
@@ -1556,12 +1557,6 @@ msgstr ""
 
 #: templates/edit_zone_templ.html:66
 msgid "Update zones"
-msgstr ""
-
-#: templates/edit_zone_templ.html:92
-msgid ""
-"To add a subdomain foo in a zonetemplate you would put foo.[ZONE] into the "
-"name field."
 msgstr ""
 
 #: templates/list_supermasters.html:40

--- a/templates/edit_zone_templ.html
+++ b/templates/edit_zone_templ.html
@@ -90,7 +90,7 @@
             <td colspan="6"><br><b>{% trans %}Examples:{% endtrans %}</b></td>
         </tr>
         <tr>
-            <td colspan="6">{% trans %}To add a subdomain foo in a zonetemplate you would put foo.[ZONE] into the name field.{% endtrans %}<br>
+            <td colspan="6">{% trans %}To add a subdomain foo in a zone template you would put foo.[ZONE] into the name field.{% endtrans %}<br>
                 {% trans %}To add a wildcard record put *.[ZONE] in the name field.{% endtrans %}<br>
                 {% trans %}Use just [ZONE] to have the domain itself return a value.{% endtrans %}<br>
                 {% trans %}For the SOA record, place [NS1] [HOSTMASTER] [SERIAL] 28800 7200 604800 86400 in the content field.{% endtrans %}


### PR DESCRIPTION
The string in question is written with a typo (zonetemplate written all together), duplicating it in the translation.

This PR corrects the typo to have only one string used in the two different twig files.