### PR TITLE
Fixed permission check in user authentication sql query

### DIFF
--- a/dynamic_update.php
+++ b/dynamic_update.php
@@ -202,7 +202,8 @@ $user = $db->queryRow("SELECT users.id, users.password FROM users, perm_templ, p
                         AND perm_templ_items.templ_id = perm_templ.id 
                         AND perm_items.id = perm_templ_items.perm_id 
                         AND (
-                            perm_items.name = 'zone_content_edit_own' 
+                            perm_items.name = 'zone_content_edit_own'
+                            OR perm_items.name = 'zone_content_edit_own_as_client'
                             OR perm_items.name = 'zone_content_edit_others'
                         )");
 


### PR DESCRIPTION
Within the dynamic_update.php script there was (in my opinion) a small error in the authentication of users. 

When checking whether the user has the appropriate rights to edit his zone, only _zone_content_edit_own_ and _zone_content_edit_others_ were checked. However, _zone_content_edit_own_as_client_ should also have the corresponding right to update its own zone via DynDNS update. 