### PR TITLE
Use the correct templates configuration

### DIFF
--- a/lib/AppManager.php
+++ b/lib/AppManager.php
@@ -58,10 +58,11 @@ class AppManager
      */
     public function __construct()
     {
-        $loader = new FilesystemLoader('templates');
-        $this->templateRenderer = new Environment($loader, ['debug' => false]);
-
         $this->configuration = new AppConfiguration();
+
+        $templates = $this->config('iface_templates');
+        $loader = new FilesystemLoader($templates);
+        $this->templateRenderer = new Environment($loader, ['debug' => false]);
 
         if ($this->config('display_stats')) {
             $memoryUsage = new MemoryUsage();


### PR DESCRIPTION
The $iface_templates configuration is never used, the templates folder is hardcoded in the code.

This PR correctly reads the variable for the Twig templates folder.

A further evolution could be to use the "templates" folder to contain the actual themes, moving the default one into a "default" subfolder and inserting any other themes there.
But since it is a braking change for now I thought of making only this small change.