### PR TITLE
Remove hardcoded css classes in textareaAutoResize

### DIFF
--- a/assets/textareaAutoResize.js
+++ b/assets/textareaAutoResize.js
@@ -14,13 +14,14 @@ function updateContentInput(selectId, containerId, contentId) {
     if (!elements.select || !elements.container) return;
 
     const currentInput = document.getElementById(contentId);
+    const currentClasses = currentInput ? currentInput.classList.toString() : '';
     const currentValue = currentInput ? currentInput.value : '';
     const currentName = currentInput ? currentInput.name : 'content';
     const isTextarea = textareaTypes.has(elements.select.value);
 
     elements.container.innerHTML = isTextarea
-        ? `<textarea id="${contentId}" class="form-control form-control-sm" name="${currentName}" rows="1" required>${currentValue}</textarea>`
-        : `<input id="${contentId}" class="form-control form-control-sm" type="text" name="${currentName}" value="${currentValue}" data-testid="record-content-input" required>`;
+        ? `<textarea id="${contentId}" class="${currentClasses}" name="${currentName}" rows="1" required>${currentValue}</textarea>`
+        : `<input id="${contentId}" class="${currentClasses}" type="text" name="${currentName}" value="${currentValue}" data-testid="record-content-input" required>`;
 
     if (isTextarea) {
         const textarea = document.getElementById(contentId);


### PR DESCRIPTION
In the auto resize inputs function has bootstrap CSS classes hardcoded.

This PR fixes the issue by reapplying the original classes in the HTML template to the elements.