### PR TITLE
Responsive pagination

### DIFF
--- a/lib/Application/Presenter/PaginationPresenter.php
+++ b/lib/Application/Presenter/PaginationPresenter.php
@@ -46,7 +46,7 @@ class PaginationPresenter
             return '';
         }
 
-        $html = '<nav><ul class="pagination">';
+        $html = '<nav><ul class="pagination d-flex flex-wrap">';
 
         if ($this->pagination->hasPreviousPage()) {
             $html .= $this->pageItem($this->pagination->getPreviousPage(), _('Previous'), false);

--- a/lib/Application/Presenter/ZoneStartingLettersPresenter.php
+++ b/lib/Application/Presenter/ZoneStartingLettersPresenter.php
@@ -28,7 +28,7 @@ class ZoneStartingLettersPresenter
     {
         $html = '<span class="text-secondary">' . _('Show zones beginning with') . "</span><br>";
         $html .= '<nav>';
-        $html .= '<ul class="pagination pagination-sm">';
+        $html .= '<ul class="pagination d-flex flex-wrap">';
 
         if ($letterStart === "1") {
             $html .= '<li class="page-item active"><span class="page-link" tabindex="-1">0-9</span></li>';


### PR DESCRIPTION
Numeric pagination and letter pagination of zones are not responsive, in case of narrow screen they are not usable.

This PR adds two flex classes to enable responsive behavior.

**Before**
![Screenshot 2025-01-07 174716](https://github.com/user-attachments/assets/202c00e6-4ae0-4c81-865d-e770dcd2f32e)

**After**
![Screenshot 2025-01-07 174513](https://github.com/user-attachments/assets/80dbc77e-0c7f-48ad-86cb-1e679fff20ae)
