### PR TITLE
Fixed issue with ie CAA records and content between quotes

### DIFF
--- a/templates/edit.html
+++ b/templates/edit.html
@@ -240,7 +240,7 @@
             </td>
             <td>
                 <div id="contentInputContainer{{ r['id'] }}">
-                    <input id="recordContent{{ r['id'] }}" class="form-control form-control-sm" type="text" name="record[{{ r['id'] }}][content]" value="{{ r['content'] }}">
+                    <input id="recordContent{{ r['id'] }}" class="form-control form-control-sm" type="text" name="record[{{ r['id'] }}][content]" value="{{ r['content']|replace({'"': '&quot;'}) }}">
                 </div>
             </td>
             <td><input class="form-control form-control-sm" type="number"


### PR DESCRIPTION
When content was set to for example `0 issue "letsencrypt.org"`, the interface would only show `0 issue ` and after submitting the content would end up without the quoted part in the database. 