### PR TITLE
feat(templates): convert static methods to instance methods and add automatic quoting for TXT records

### DIFF
--- a/lib/Application/Controller/AddZoneTemplRecordController.php
+++ b/lib/Application/Controller/AddZoneTemplRecordController.php
@@ -82,7 +82,9 @@ class AddZoneTemplRecordController extends BaseController
         $dns_ttl = $this->config('dns_ttl');
         $ttl = $_POST['ttl'] ?? $dns_ttl;
 
-        if (ZoneTemplate::add_zone_templ_record($this->db, $zone_templ_id, $name, $type, $content, $ttl, $prio)) {
+        $template = new ZoneTemplate($this->db, $this->getConfig());
+
+        if ($template->add_zone_templ_record($zone_templ_id, $name, $type, $content, $ttl, $prio)) {
             $this->setMessage('edit_zone_templ', 'success', 'The record was successfully added.');
             $this->redirect('index.php', ['page' => 'edit_zone_templ', 'id' => $zone_templ_id]);
         } else {

--- a/lib/Application/Controller/EditZoneTemplRecordController.php
+++ b/lib/Application/Controller/EditZoneTemplRecordController.php
@@ -82,7 +82,9 @@ class EditZoneTemplRecordController extends BaseController
 
     public function updateZoneTemplateRecord(string $zone_templ_id): void
     {
-        if (ZoneTemplate::edit_zone_templ_record($this->db, $_POST)) {
+        $template = new ZoneTemplate($this->db, $this->getConfig());
+
+        if ($template->edit_zone_templ_record($_POST)) {
             $this->setMessage('edit_zone_templ', 'success', _('Zone template has been updated successfully.'));
             $this->redirect('index.php', ['page' => 'edit_zone_templ', 'id' => $zone_templ_id]);
         }


### PR DESCRIPTION
This PR adds the auto-quoting functionality for TXT records also for templates.

In order to read the config inside the template, the methods have been changed from static to instances.

Related to #361 