### PR TITLE
Problem with external powerdns db after upgrading from 3.9.2 to 4.0.0

### DIFF
--- a/dynamic_update.php
+++ b/dynamic_update.php
@@ -15,7 +15,7 @@ $config = ConfigurationManager::getInstance();
 $config->initialize();
 
 $db_type = $config->get('database', 'type');
-$pdns_db_name = $config->get('database', 'pdns_name');
+$pdns_db_name = $config->get('database', 'pdns_db_name');
 $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
 $credentials = [

--- a/lib/Application/Controller/Api/V1/ZonesRecordsController.php
+++ b/lib/Application/Controller/Api/V1/ZonesRecordsController.php
@@ -632,7 +632,7 @@ class ZonesRecordsController extends PublicApiController
     {
         try {
             $config = $this->getConfig();
-            $pdns_db_name = $config->get('database', 'pdns_name');
+            $pdns_db_name = $config->get('database', 'pdns_db_name');
             $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
             // Basic record validation
@@ -686,7 +686,7 @@ class ZonesRecordsController extends PublicApiController
     {
         try {
             $config = $this->getConfig();
-            $pdns_db_name = $config->get('database', 'pdns_name');
+            $pdns_db_name = $config->get('database', 'pdns_db_name');
             $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
             // Get current SOA record

--- a/lib/Application/Query/RecordSearch.php
+++ b/lib/Application/Query/RecordSearch.php
@@ -100,7 +100,7 @@ class RecordSearch extends BaseSearch
     ): array {
         $offset = ($page - 1) * $iface_rowamount;
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
         $comments_table = $pdns_db_name ? $pdns_db_name . '.comments' : 'comments';
 
@@ -203,7 +203,7 @@ class RecordSearch extends BaseSearch
      */
     public function getFoundRecords(array $parameters, mixed $search_string, bool $reverse, mixed $reverse_search_string, string $permission_view, bool $iface_search_group_records): int
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
         $comments_table = $pdns_db_name ? $pdns_db_name . '.comments' : 'comments';
         $groupByClause = $iface_search_group_records ? "GROUP BY $records_table.name, $records_table.content" : '';

--- a/lib/Application/Query/ZoneSearch.php
+++ b/lib/Application/Query/ZoneSearch.php
@@ -109,7 +109,7 @@ class ZoneSearch extends BaseSearch
     ): array {
         $offset = ($page - 1) * $iface_rowamount;
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
@@ -185,7 +185,7 @@ class ZoneSearch extends BaseSearch
      */
     public function getFoundZones(array $parameters, mixed $search_string, bool $reverse, mixed $reverse_search_string, string $permission_view): int
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 

--- a/lib/Domain/Model/ZoneTemplate.php
+++ b/lib/Domain/Model/ZoneTemplate.php
@@ -686,7 +686,7 @@ class ZoneTemplate
     {
         $perm_edit = Permission::getEditPermission($this->db);
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
@@ -738,7 +738,7 @@ class ZoneTemplate
     {
         $perm_edit = Permission::getEditPermission($this->db);
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
@@ -856,7 +856,7 @@ class ZoneTemplate
         }
 
         try {
-            $pdns_db_name = $this->config->get('database', 'pdns_name');
+            $pdns_db_name = $this->config->get('database', 'pdns_db_name');
             $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
 
             $placeholders = str_repeat('?,', count($zone_ids) - 1) . '?';

--- a/lib/Domain/Repository/DomainRepository.php
+++ b/lib/Domain/Repository/DomainRepository.php
@@ -67,7 +67,7 @@ class DomainRepository implements DomainRepositoryInterface
      */
     public function zoneIdExists(int $zid): int
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
 
         $stmt = $this->db->prepare("SELECT COUNT(id) FROM $domains_table WHERE id = :id");
@@ -84,7 +84,7 @@ class DomainRepository implements DomainRepositoryInterface
      */
     public function getDomainNameById(int $id): ?string
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
 
         $stmt = $this->db->prepare("SELECT name FROM $domains_table WHERE id = :id");
@@ -110,7 +110,7 @@ class DomainRepository implements DomainRepositoryInterface
             return null;
         }
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
 
         $query = "SELECT id FROM $domains_table WHERE name = :name";
@@ -134,7 +134,7 @@ class DomainRepository implements DomainRepositoryInterface
             return null;
         }
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
 
         $stmt = $this->db->prepare("SELECT id FROM $domains_table WHERE name = :name");
@@ -153,7 +153,7 @@ class DomainRepository implements DomainRepositoryInterface
      */
     public function getDomainType(int $id): string
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
 
         $stmt = $this->db->prepare("SELECT type FROM $domains_table WHERE id = :id");
@@ -174,7 +174,7 @@ class DomainRepository implements DomainRepositoryInterface
      */
     public function getDomainSlaveMaster(int $id): ?string
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
 
         $stmt = $this->db->prepare("SELECT master FROM $domains_table WHERE type = 'SLAVE' and id = :id");
@@ -191,7 +191,7 @@ class DomainRepository implements DomainRepositoryInterface
      */
     public function domainExists(string $domain): bool
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
 
         if ($this->hostnameValidator->isValid($domain)) {
@@ -226,7 +226,7 @@ class DomainRepository implements DomainRepositoryInterface
         $iface_zonelist_serial = $this->config->get('interface', 'display_serial_in_zone_list');
         $iface_zonelist_template = $this->config->get('interface', 'display_template_in_zone_list');
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
         $cryptokeys_table = $pdns_db_name ? $pdns_db_name . '.cryptokeys' : 'cryptokeys';
@@ -350,7 +350,7 @@ class DomainRepository implements DomainRepositoryInterface
             $this->messageService->addSystemError(_("You do not have the permission to view this zone."));
             return [];
         } else {
-            $pdns_db_name = $this->config->get('database', 'pdns_name');
+            $pdns_db_name = $this->config->get('database', 'pdns_db_name');
             $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
             $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
@@ -405,7 +405,7 @@ class DomainRepository implements DomainRepositoryInterface
         $match = 72; // the longest ip6.arpa has a length of 72
         $found_domain_id = -1;
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
 
         // get all reverse-zones

--- a/lib/Domain/Repository/RecordRepository.php
+++ b/lib/Domain/Repository/RecordRepository.php
@@ -61,7 +61,7 @@ class RecordRepository implements RecordRepositoryInterface
      */
     public function getZoneIdFromRecordId(int $rid): int
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $stmt = $this->db->prepare("SELECT domain_id FROM $records_table WHERE id = :id");
@@ -78,7 +78,7 @@ class RecordRepository implements RecordRepositoryInterface
      */
     public function countZoneRecords(int $zone_id): int
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $stmt = $this->db->prepare("SELECT COUNT(id) FROM $records_table WHERE domain_id = :zone_id AND type IS NOT NULL");
@@ -95,7 +95,7 @@ class RecordRepository implements RecordRepositoryInterface
      */
     public function getRecordDetailsFromRecordId(int $rid): array
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $stmt = $this->db->prepare("SELECT id AS rid, domain_id AS zid, name, type, content, ttl, prio FROM $records_table WHERE id = :id");
@@ -113,7 +113,7 @@ class RecordRepository implements RecordRepositoryInterface
      */
     public function getRecordFromId(int $id): ?array
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $stmt = $this->db->prepare("SELECT * FROM $records_table WHERE id = :id AND type IS NOT NULL");
@@ -162,7 +162,7 @@ class RecordRepository implements RecordRepositoryInterface
             return [];
         }
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
         $comments_table = $pdns_db_name ? $pdns_db_name . '.comments' : 'comments';
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
@@ -225,7 +225,7 @@ class RecordRepository implements RecordRepositoryInterface
      */
     public function recidToDomid(int $id): int
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $stmt = $this->db->prepare("SELECT domain_id FROM $records_table WHERE id = :id");
@@ -243,7 +243,7 @@ class RecordRepository implements RecordRepositoryInterface
      */
     public function recordNameExists(string $name): bool
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $stmt = $this->db->prepare("SELECT COUNT(id) FROM $records_table WHERE name = :name");
@@ -263,7 +263,7 @@ class RecordRepository implements RecordRepositoryInterface
      */
     public function hasSimilarRecords(int $domain_id, string $name, string $type, int $record_id): bool
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $query = "SELECT COUNT(*) FROM $records_table
@@ -289,7 +289,7 @@ class RecordRepository implements RecordRepositoryInterface
      */
     public function recordExists(int $domain_id, string $name, string $type, string $content): bool
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $stmt = $this->db->prepare("SELECT COUNT(*) FROM $records_table 
@@ -316,7 +316,7 @@ class RecordRepository implements RecordRepositoryInterface
      */
     public function hasPtrRecord(int $domain_id, string $name): bool
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $stmt = $this->db->prepare("SELECT COUNT(*) FROM $records_table 
@@ -339,7 +339,7 @@ class RecordRepository implements RecordRepositoryInterface
      */
     public function getSerialByZid(int $zid): string
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $stmt = $this->db->prepare("SELECT content FROM $records_table WHERE type = :type AND domain_id = :domain_id");
@@ -377,7 +377,7 @@ class RecordRepository implements RecordRepositoryInterface
         string $type_filter = '',
         string $content_filter = ''
     ): array {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
         $comments_table = $pdns_db_name ? $pdns_db_name . '.comments' : 'comments';
 
@@ -465,7 +465,7 @@ class RecordRepository implements RecordRepositoryInterface
         string $type_filter = '',
         string $content_filter = ''
     ): int {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         // Prepare query parameters
@@ -524,7 +524,7 @@ class RecordRepository implements RecordRepositoryInterface
      */
     public function getNewRecordId(int $domainId, string $name, string $type, string $content): ?int
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $query = "SELECT id FROM $records_table
@@ -548,7 +548,7 @@ class RecordRepository implements RecordRepositoryInterface
 
     public function getRecordsByDomainId(int $domainId, ?string $recordType = null): array
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $query = "SELECT id, domain_id, name, type, content, ttl, prio, disabled, ordername, auth
@@ -572,7 +572,7 @@ class RecordRepository implements RecordRepositoryInterface
 
     public function getRecordById(int $recordId): ?array
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $query = "SELECT id, domain_id, name, type, content, ttl, prio, disabled, ordername, auth

--- a/lib/Domain/Service/Dns/DomainManager.php
+++ b/lib/Domain/Service/Dns/DomainManager.php
@@ -92,7 +92,7 @@ class DomainManager implements DomainManagerInterface
             $dns_ttl = $this->config->get('dns', 'ttl');
             $db_type = $this->config->get('database', 'type');
 
-            $pdns_db_name = $this->config->get('database', 'pdns_name');
+            $pdns_db_name = $this->config->get('database', 'pdns_db_name');
             $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
             $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
@@ -224,7 +224,7 @@ class DomainManager implements DomainManagerInterface
         $perm_edit = Permission::getEditPermission($this->db);
         $user_is_zone_owner = UserManager::verifyUserIsOwnerZoneId($this->db, $id);
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
@@ -257,7 +257,7 @@ class DomainManager implements DomainManagerInterface
     public function deleteDomains(array $domains): bool
     {
         $pdnssec_use = $this->config->get('dnssec', 'enabled');
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? "$pdns_db_name.domains" : "domains";
         $records_table = $pdns_db_name ? "$pdns_db_name.records" : "records";
 
@@ -317,7 +317,7 @@ class DomainManager implements DomainManagerInterface
      */
     public function changeZoneType(string $type, int $id): void
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
 
         $add = '';
@@ -346,7 +346,7 @@ class DomainManager implements DomainManagerInterface
     public function changeZoneSlaveMaster(int $zone_id, string $ip_slave_master)
     {
         if ($this->ipAddressValidator->areMultipleValidIPs($ip_slave_master)) {
-            $pdns_db_name = $this->config->get('database', 'pdns_name');
+            $pdns_db_name = $this->config->get('database', 'pdns_db_name');
             $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
 
             $stmt = $this->db->prepare("UPDATE $domains_table SET master = ? WHERE id = ?");
@@ -459,7 +459,7 @@ class DomainManager implements DomainManagerInterface
         $soa_rec = $this->soaRecordManager->getSOARecord($zone_id);
         $this->db->beginTransaction();
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         if ($zone_template_id != 0) {

--- a/lib/Domain/Service/Dns/RecordManager.php
+++ b/lib/Domain/Service/Dns/RecordManager.php
@@ -157,7 +157,7 @@ class RecordManager implements RecordManagerInterface
 
         $this->db->beginTransaction();
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $query = "INSERT INTO $records_table (domain_id, name, type, content, ttl, prio) VALUES (:zone_id, :name, :type, :content, :ttl, :prio)";
@@ -254,7 +254,7 @@ class RecordManager implements RecordManagerInterface
                 $validatedTtl = $validatedData['ttl'];
                 $validatedPrio = $validatedData['prio'];
 
-                $pdns_db_name = $this->config->get('database', 'pdns_name');
+                $pdns_db_name = $this->config->get('database', 'pdns_db_name');
                 $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
                 $stmt = $this->db->prepare("UPDATE $records_table
@@ -301,7 +301,7 @@ class RecordManager implements RecordManagerInterface
                 }
 
                 // Admins and regular zone owners can delete SOA records
-                $pdns_db_name = $this->config->get('database', 'pdns_name');
+                $pdns_db_name = $this->config->get('database', 'pdns_db_name');
                 $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
                 $stmt = $this->db->prepare("DELETE FROM $records_table WHERE id = ?");
@@ -312,7 +312,7 @@ class RecordManager implements RecordManagerInterface
                 $this->messageService->addSystemError(_('You do not have the permission to delete NS records.'));
                 return false;
             } else {
-                $pdns_db_name = $this->config->get('database', 'pdns_name');
+                $pdns_db_name = $this->config->get('database', 'pdns_db_name');
                 $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
                 $stmt = $this->db->prepare("DELETE FROM $records_table WHERE id = ?");

--- a/lib/Domain/Service/Dns/SOARecordManager.php
+++ b/lib/Domain/Service/Dns/SOARecordManager.php
@@ -54,7 +54,7 @@ class SOARecordManager implements SOARecordManagerInterface
      */
     public function getSOARecord(int $zone_id): string
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $stmt = $this->db->prepare("SELECT content FROM $records_table WHERE type = ? AND domain_id = ?");
@@ -172,7 +172,7 @@ class SOARecordManager implements SOARecordManagerInterface
      */
     public function updateSOARecord(int $domain_id, string $content): bool
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $stmt = $this->db->prepare("UPDATE $records_table SET content = ? WHERE domain_id = ? AND type = ?");

--- a/lib/Domain/Service/Dns/SupermasterManager.php
+++ b/lib/Domain/Service/Dns/SupermasterManager.php
@@ -86,7 +86,7 @@ class SupermasterManager implements SupermasterManagerInterface
             $this->messageService->addSystemError(_('There is already a supermaster with this IP address and hostname.'));
             return false;
         } else {
-            $pdns_db_name = $this->config->get('database', 'pdns_name');
+            $pdns_db_name = $this->config->get('database', 'pdns_db_name');
             $supermasters_table = $pdns_db_name ? $pdns_db_name . ".supermasters" : "supermasters";
 
             $stmt = $this->db->prepare("INSERT INTO $supermasters_table (ip, nameserver, account) VALUES (:master_ip, :ns_name, :account)");
@@ -112,7 +112,7 @@ class SupermasterManager implements SupermasterManagerInterface
     public function deleteSupermaster(string $master_ip, string $ns_name): bool
     {
         if ($this->ipAddressValidator->isValidIPv4($master_ip) || $this->ipAddressValidator->isValidIPv6($master_ip) || $this->hostnameValidator->isValid($ns_name)) {
-            $pdns_db_name = $this->config->get('database', 'pdns_name');
+            $pdns_db_name = $this->config->get('database', 'pdns_db_name');
             $supermasters_table = $pdns_db_name ? $pdns_db_name . ".supermasters" : "supermasters";
 
             $stmt = $this->db->prepare("DELETE FROM $supermasters_table WHERE ip = :master_ip AND nameserver = :ns_name");
@@ -136,7 +136,7 @@ class SupermasterManager implements SupermasterManagerInterface
      */
     public function getSupermasters(): array
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $supermasters_table = $pdns_db_name ? $pdns_db_name . ".supermasters" : "supermasters";
 
         $result = $this->db->query("SELECT ip, nameserver, account FROM $supermasters_table");
@@ -165,7 +165,7 @@ class SupermasterManager implements SupermasterManagerInterface
     public function getSupermasterInfoFromIp(string $master_ip): array
     {
         if ($this->ipAddressValidator->isValidIPv4($master_ip) || $this->ipAddressValidator->isValidIPv6($master_ip)) {
-            $pdns_db_name = $this->config->get('database', 'pdns_name');
+            $pdns_db_name = $this->config->get('database', 'pdns_db_name');
             $supermasters_table = $pdns_db_name ? $pdns_db_name . ".supermasters" : "supermasters";
 
             $stmt = $this->db->prepare("SELECT ip,nameserver,account FROM $supermasters_table WHERE ip = :master_ip");
@@ -193,7 +193,7 @@ class SupermasterManager implements SupermasterManagerInterface
     public function supermasterExists(string $master_ip): bool
     {
         if ($this->ipAddressValidator->isValidIPv4($master_ip) || $this->ipAddressValidator->isValidIPv6($master_ip)) {
-            $pdns_db_name = $this->config->get('database', 'pdns_name');
+            $pdns_db_name = $this->config->get('database', 'pdns_db_name');
             $supermasters_table = $pdns_db_name ? $pdns_db_name . ".supermasters" : "supermasters";
 
             $stmt = $this->db->prepare("SELECT ip FROM $supermasters_table WHERE ip = :master_ip");
@@ -217,7 +217,7 @@ class SupermasterManager implements SupermasterManagerInterface
     public function supermasterIpNameExists(string $master_ip, string $ns_name): bool
     {
         if (($this->ipAddressValidator->isValidIPv4($master_ip) || $this->ipAddressValidator->isValidIPv6($master_ip)) && $this->hostnameValidator->isValid($ns_name)) {
-            $pdns_db_name = $this->config->get('database', 'pdns_name');
+            $pdns_db_name = $this->config->get('database', 'pdns_db_name');
             $supermasters_table = $pdns_db_name ? $pdns_db_name . ".supermasters" : "supermasters";
 
             $stmt = $this->db->prepare("SELECT ip FROM $supermasters_table WHERE ip = :master_ip AND nameserver = :ns_name");
@@ -281,7 +281,7 @@ class SupermasterManager implements SupermasterManagerInterface
             return false;
         }
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $supermasters_table = $pdns_db_name ? $pdns_db_name . ".supermasters" : "supermasters";
 
         $stmt = $this->db->prepare("UPDATE $supermasters_table SET ip = :new_master_ip, nameserver = :new_ns_name, account = :account 
@@ -305,7 +305,7 @@ class SupermasterManager implements SupermasterManagerInterface
      */
     public function getSlaveServerIPs(): array
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $supermasters_table = $pdns_db_name ? $pdns_db_name . ".supermasters" : "supermasters";
 
         $result = $this->db->query("SELECT ip FROM $supermasters_table GROUP BY ip");

--- a/lib/Domain/Service/DnsValidation/CNAMERecordValidator.php
+++ b/lib/Domain/Service/DnsValidation/CNAMERecordValidator.php
@@ -177,7 +177,7 @@ class CNAMERecordValidator implements DnsRecordValidatorInterface
      */
     private function validateCnameUnique(string $name, int $rid): ValidationResult
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         // Check if there are any records with this name
@@ -209,7 +209,7 @@ class CNAMERecordValidator implements DnsRecordValidatorInterface
      */
     private function validateCnameName(string $name): ValidationResult
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $query = "SELECT id FROM $records_table WHERE content = ? AND (type = ? OR type = ?)";
@@ -251,7 +251,7 @@ class CNAMERecordValidator implements DnsRecordValidatorInterface
      */
     public function validateCnameExistence(string $name, int $rid): ValidationResult
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         if ($rid > 0) {

--- a/lib/Domain/Service/DnsValidation/DNSViolationValidator.php
+++ b/lib/Domain/Service/DnsValidation/DNSViolationValidator.php
@@ -123,7 +123,7 @@ class DNSViolationValidator
      */
     private function checkDuplicateCNAME(int $recordId, int $zoneId, string $name): ValidationResult
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         // Using native PDO parameter binding for security
@@ -170,7 +170,7 @@ class DNSViolationValidator
      */
     private function checkCNAMEConflictsWithOtherTypes(int $recordId, int $zoneId, string $name): ValidationResult
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         if ($recordId > 0) {
@@ -218,7 +218,7 @@ class DNSViolationValidator
      */
     private function validateConflictsWithCNAME(int $recordId, int $zoneId, string $name): ValidationResult
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         if ($recordId > 0) {

--- a/lib/Domain/Service/DnsValidation/DnsCommonValidator.php
+++ b/lib/Domain/Service/DnsValidation/DnsCommonValidator.php
@@ -89,7 +89,7 @@ class DnsCommonValidator
      */
     public function validateNonAliasTarget(string $target): ValidationResult
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $stmt = $this->db->prepare("SELECT id FROM $records_table

--- a/lib/Domain/Service/ReverseRecordCreator.php
+++ b/lib/Domain/Service/ReverseRecordCreator.php
@@ -109,7 +109,7 @@ class ReverseRecordCreator
             return false;
         }
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         // Look for a PTR record pointing to this name
@@ -199,7 +199,7 @@ class ReverseRecordCreator
      */
     private function ptrRecordExists(int $zone_id, string $name, string $content): bool
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $records_table = $pdns_db_name ? $pdns_db_name . '.records' : 'records';
 
         $query = "SELECT COUNT(*) FROM $records_table 

--- a/lib/Domain/Service/ZoneCountService.php
+++ b/lib/Domain/Service/ZoneCountService.php
@@ -59,7 +59,7 @@ class ZoneCountService
      */
     public function countZones(string $perm, string $letterstart = 'all', string $zone_type = 'forward'): int
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
 
         $tables = $domains_table;

--- a/lib/Infrastructure/Configuration/ConfigurationManager.php
+++ b/lib/Infrastructure/Configuration/ConfigurationManager.php
@@ -164,7 +164,7 @@ class ConfigurationManager implements ConfigurationInterface
 
         // In the database section:
         if (isset($legacyConfig['pdns_db_name'])) {
-            $newConfig['database']['pdns_name'] = $legacyConfig['pdns_db_name'];
+            $newConfig['database']['pdns_db_name'] = $legacyConfig['pdns_db_name'];
         }
 
         // Database settings

--- a/lib/Infrastructure/Logger/DbZoneLogger.php
+++ b/lib/Infrastructure/Logger/DbZoneLogger.php
@@ -56,7 +56,7 @@ class DbZoneLogger
 
     public function countLogsByDomain($domain)
     {
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? "$pdns_db_name.domains" : "domains";
 
         $stmt = $this->db->prepare("
@@ -95,7 +95,7 @@ class DbZoneLogger
             return array();
         }
 
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $domains_table = $pdns_db_name ? "$pdns_db_name.domains" : "domains";
 
         $stmt = $this->db->prepare("

--- a/lib/Infrastructure/Repository/DbRecordCommentRepository.php
+++ b/lib/Infrastructure/Repository/DbRecordCommentRepository.php
@@ -35,7 +35,7 @@ class DbRecordCommentRepository implements RecordCommentRepositoryInterface
     public function __construct(PDO $connection, ConfigurationManager $config)
     {
         $this->connection = $connection;
-        $pdns_db_name = $config->get('database', 'pdns_name');
+        $pdns_db_name = $config->get('database', 'pdns_db_name');
         $this->comments_table = $pdns_db_name ? $pdns_db_name . '.comments' : 'comments';
     }
 

--- a/lib/Infrastructure/Repository/DbZoneRepository.php
+++ b/lib/Infrastructure/Repository/DbZoneRepository.php
@@ -47,7 +47,7 @@ class DbZoneRepository implements ZoneRepositoryInterface
         $this->db = $db;
         $this->config = $config;
         $this->db_type = $config->get('database', 'type');
-        $this->pdns_db_name = $config->get('database', 'pdns_name');
+        $this->pdns_db_name = $config->get('database', 'pdns_db_name');
         $this->naturalSorting = new NaturalSorting();
         $this->reverseDomainNaturalSorting = new ReverseDomainNaturalSorting();
         $this->reverseZoneSorting = new ReverseZoneSorting();

--- a/lib/Infrastructure/Service/PdnsUtilProvider.php
+++ b/lib/Infrastructure/Service/PdnsUtilProvider.php
@@ -186,7 +186,7 @@ class PdnsUtilProvider implements DnssecProvider
     public function isZoneSecured(string $zoneName, $config): bool
     {
         // Use our own configuration instance instead of the passed one
-        $pdns_db_name = $this->config->get('database', 'pdns_name');
+        $pdns_db_name = $this->config->get('database', 'pdns_db_name');
         $cryptokeys_table = $pdns_db_name ? $pdns_db_name . '.cryptokeys' : 'cryptokeys';
         $domains_table = $pdns_db_name ? $pdns_db_name . '.domains' : 'domains';
         $domainmetadata_table = $pdns_db_name ? $pdns_db_name . '.domainmetadata' : 'domainmetadata';

--- a/tests/helpers/BaseDnsTest.php
+++ b/tests/helpers/BaseDnsTest.php
@@ -58,7 +58,7 @@ class BaseDnsTest extends TestCase
                 }
 
                 // For database tests
-                if ($group === 'database' && $key === 'pdns_name') {
+                if ($group === 'database' && $key === 'pdns_db_name') {
                     return 'pdns';  // Mock database name for tests
                 }
 

--- a/tests/unit/ConfigurationManagerTest.php
+++ b/tests/unit/ConfigurationManagerTest.php
@@ -213,7 +213,7 @@ class ConfigurationManagerTest extends TestCase
         $this->assertEquals('testuser', $newConfig['database']['user']);
         $this->assertEquals('testpass', $newConfig['database']['password']);
         $this->assertEquals('testdb', $newConfig['database']['name']);
-        $this->assertEquals('pdnsdb', $newConfig['database']['pdns_name']);
+        $this->assertEquals('pdnsdb', $newConfig['database']['pdns_db_name']);
 
         $this->assertEquals('testsecret', $newConfig['security']['session_key']);
         $this->assertEquals('bcrypt', $newConfig['security']['password_encryption']);

--- a/tests/unit/Dns/DNSViolationValidatorTest.php
+++ b/tests/unit/Dns/DNSViolationValidatorTest.php
@@ -52,7 +52,7 @@ class DNSViolationValidatorTest extends TestCase
     {
         // Mock configuration
         $this->configMock->method('get')
-            ->with('database', 'pdns_name')
+            ->with('database', 'pdns_db_name')
             ->willReturn('');
 
         // Configure statement mock to return no conflicts
@@ -70,7 +70,7 @@ class DNSViolationValidatorTest extends TestCase
     {
         // Mock configuration
         $this->configMock->method('get')
-            ->with('database', 'pdns_name')
+            ->with('database', 'pdns_db_name')
             ->willReturn('');
 
         // Configure statement mock to return no conflicts for both queries
@@ -88,7 +88,7 @@ class DNSViolationValidatorTest extends TestCase
     {
         // Mock configuration
         $this->configMock->method('get')
-            ->with('database', 'pdns_name')
+            ->with('database', 'pdns_db_name')
             ->willReturn('');
 
         // Configure statement mock to return a duplicate on first call (count of CNAME records)
@@ -107,7 +107,7 @@ class DNSViolationValidatorTest extends TestCase
     {
         // Mock configuration
         $this->configMock->method('get')
-            ->with('database', 'pdns_name')
+            ->with('database', 'pdns_db_name')
             ->willReturn('');
 
         // First call should return false (no duplicate CNAMEs), second call should return 'A' (conflicting record type)
@@ -127,7 +127,7 @@ class DNSViolationValidatorTest extends TestCase
     {
         // Mock configuration
         $this->configMock->method('get')
-            ->with('database', 'pdns_name')
+            ->with('database', 'pdns_db_name')
             ->willReturn('');
 
         // Configure statement mock to return an existing CNAME record ID

--- a/tests/unit/DnsRecordTest.php
+++ b/tests/unit/DnsRecordTest.php
@@ -26,7 +26,7 @@ class DnsRecordTest extends TestCase
                 if ($group === 'database' && $key === 'type') {
                     return 'mysql'; // Mock database type for tests
                 }
-                if ($group === 'database' && $key === 'pdns_name') {
+                if ($group === 'database' && $key === 'pdns_db_name') {
                     return 'pdns'; // Mock PowerDNS database name
                 }
                 return null;

--- a/tests/unit/RecordRepositoryApexSortingTest.php
+++ b/tests/unit/RecordRepositoryApexSortingTest.php
@@ -45,7 +45,7 @@ class RecordRepositoryApexSortingTest extends TestCase
         $this->config = $this->createMock(ConfigurationManager::class);
         $this->config->method('get')
             ->willReturnCallback(function ($section, $key, $default = null) {
-                if ($section === 'database' && $key === 'pdns_name') {
+                if ($section === 'database' && $key === 'pdns_db_name') {
                     return null; // No prefix
                 }
                 if ($section === 'database' && $key === 'type') {

--- a/tests/unit/ZoneCountTest.php
+++ b/tests/unit/ZoneCountTest.php
@@ -27,7 +27,7 @@ class ZoneCountTest extends TestCase
         $this->configMock->expects($this->atLeastOnce())
             ->method('get')
             ->willReturnCallback(function ($group, $key) {
-                if ($group === 'database' && $key === 'pdns_name') {
+                if ($group === 'database' && $key === 'pdns_db_name') {
                     return null; // No prefix for tables
                 }
                 if ($group === 'database' && $key === 'type') {
@@ -55,7 +55,7 @@ class ZoneCountTest extends TestCase
         $this->configMock->expects($this->atLeastOnce())
             ->method('get')
             ->willReturnCallback(function ($group, $key) {
-                if ($group === 'database' && $key === 'pdns_name') {
+                if ($group === 'database' && $key === 'pdns_db_name') {
                     return null; // No prefix for tables
                 }
                 if ($group === 'database' && $key === 'type') {
@@ -83,7 +83,7 @@ class ZoneCountTest extends TestCase
         $this->configMock->expects($this->atLeastOnce())
             ->method('get')
             ->willReturnCallback(function ($group, $key) {
-                if ($group === 'database' && $key === 'pdns_name') {
+                if ($group === 'database' && $key === 'pdns_db_name') {
                     return null; // No prefix for tables
                 }
                 if ($group === 'database' && $key === 'type') {
@@ -114,7 +114,7 @@ class ZoneCountTest extends TestCase
         $this->configMock->expects($this->atLeastOnce())
             ->method('get')
             ->willReturnCallback(function ($group, $key) {
-                if ($group === 'database' && $key === 'pdns_name') {
+                if ($group === 'database' && $key === 'pdns_db_name') {
                     return null; // No prefix for tables
                 }
                 if ($group === 'database' && $key === 'type') {
@@ -148,7 +148,7 @@ class ZoneCountTest extends TestCase
         $this->configMock->expects($this->atLeastOnce())
             ->method('get')
             ->willReturnCallback(function ($group, $key) {
-                if ($group === 'database' && $key === 'pdns_name') {
+                if ($group === 'database' && $key === 'pdns_db_name') {
                     return null; // No prefix for tables
                 }
                 if ($group === 'database' && $key === 'type') {
@@ -179,7 +179,7 @@ class ZoneCountTest extends TestCase
         $this->configMock->expects($this->atLeastOnce())
             ->method('get')
             ->willReturnCallback(function ($group, $key) {
-                if ($group === 'database' && $key === 'pdns_name') {
+                if ($group === 'database' && $key === 'pdns_db_name') {
                     return null; // No prefix for tables
                 }
                 if ($group === 'database' && $key === 'type') {
@@ -207,7 +207,7 @@ class ZoneCountTest extends TestCase
         $this->configMock->expects($this->atLeastOnce())
             ->method('get')
             ->willReturnCallback(function ($group, $key) {
-                if ($group === 'database' && $key === 'pdns_name') {
+                if ($group === 'database' && $key === 'pdns_db_name') {
                     return 'pdns'; // Add prefix for tables
                 }
                 if ($group === 'database' && $key === 'type') {


### PR DESCRIPTION
Hello,

I think I found small typo in the code, where the name of the external powerdns database is read in:

config->get('database', 'pdns_name') 

reads 'pdns_name' instead of 'pdns_db_name'.

And I think you should add a hint for users with an external powerdns db, when reading in the database upgrade file for 4.0.0.
They have to edit the sql statements where the "FOREIGN KEY" is defined for table `zone_template_sync` and the following "INSERT INTO zone_template_sync" statement (FROM domains d).

Kind regards,
Muckl