### PR TITLE
fix(email): when sending multipart emails, the boundary code is generated twice

### DIFF
--- a/config/settings.defaults.php
+++ b/config/settings.defaults.php
@@ -172,10 +172,11 @@ return [
      * Mail Settings
      */
     'mail' => [
-        'enabled' => true,                         // Enable email functionality
-        'from' => 'poweradmin@example.com',        // Default "from" address
-        'from_name' => '',                         // Default "from" name
-        'transport' => 'php',                      // Transport method: smtp, sendmail, or php
+        'enabled' => true,                          // Enable email functionality
+        'from' => 'poweradmin@example.com',         // Default "from" address
+        'from_name' => '',                          // Default "from" name
+        'return_path' => 'poweradmin@example.com',  // Default "Return-Path" address
+        'transport' => 'php',                       // Transport method: smtp, sendmail, or php
 
         // SMTP settings
         'host' => 'smtp.example.com',              // SMTP server hostname

--- a/lib/Application/Service/MailService.php
+++ b/lib/Application/Service/MailService.php
@@ -196,10 +196,10 @@ class MailService implements MailServiceInterface
         $messageBody = $this->getMessageBody($body, $plainBody, $boundary);
 
         // add "Return-Path" to Header
-        $return_path = "-f".$this->config->get('mail', 'return_path', 'poweradmin@example.com');
+        $returnPath = "-f" . $this->config->get('mail', 'return_path', 'poweradmin@example.com');
 
         // Send the email
-        return mail($to, $subject, $messageBody, $headersStr, $return_path);
+        return mail($to, $subject, $messageBody, $headersStr, $returnPath);
     }
 
     /**

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -193,7 +193,6 @@
   <file src="lib/Application/Service/MailService.php">
     <InvalidScalarArgument>
       <code><![CDATA[time()]]></code>
-      <code><![CDATA[time()]]></code>
     </InvalidScalarArgument>
   </file>
   <file src="lib/Application/Service/RdapService.php">


### PR DESCRIPTION
Hello Edmondas,

I hope that this is the right way to correct this.

Greets,
Michael