### PR TITLE
nginx-conf: removed install and vendor from deny filter.

### DIFF
--- a/nginx.conf.example
+++ b/nginx.conf.example
@@ -109,7 +109,7 @@ server {
         deny all;
     }
     
-    location ~ /(config|lib|install|vendor|tests|tools)/ {
+    location ~ /(config|lib|tests|tools)/ {
         deny all;
     }
     


### PR DESCRIPTION
Deny access to the vendor directory would block access to css in vendor/twbs/bootstrap.
The install directory is needed by the installer and will be removed after the installation.
 