### PR TITLE
pdns-display: added 'display_name' to 'pdns_api' config group, show '…

### DIFF
--- a/config/settings.defaults.php
+++ b/config/settings.defaults.php
@@ -207,6 +207,7 @@ return [
      * PowerDNS API Settings
      */
     'pdns_api' => [
+        'display_name' => 'PowerDNS',              // PowerDNS name to identify server
         'url' => '',                               // PowerDNS API URL, e.g., 'http://127.0.0.1:8081' (added in 3.7.0)
         'key' => '',                               // PowerDNS API key (added in 3.7.0)
         'server_name' => 'localhost',              // PowerDNS server name used in API calls (added in 4.0.0)

--- a/lib/Application/Controller/IndexController.php
+++ b/lib/Application/Controller/IndexController.php
@@ -88,6 +88,7 @@ class IndexController extends BaseController
             $statusService = new \Poweradmin\Application\Service\PowerdnsStatusService();
             $serverStatus = $statusService->getServerStatus();
             $pdnsServerStatus = [
+                'display' => $serverStatus['display_name'] ?? 'localhost',
                 'running' => $serverStatus['running'] ?? false,
                 'version' => $serverStatus['version'] ?? 'unknown'
             ];

--- a/lib/Application/Service/PowerdnsStatusService.php
+++ b/lib/Application/Service/PowerdnsStatusService.php
@@ -34,6 +34,7 @@ class PowerdnsStatusService
     private bool $apiEnabled;
     private string $apiUrl;
     private string $apiKey;
+    private string $displayName;
     private string $serverName;
 
     public function __construct()
@@ -41,6 +42,7 @@ class PowerdnsStatusService
         $config = ConfigurationManager::getInstance();
         $this->apiUrl = $config->get('pdns_api', 'url', '');
         $this->apiKey = $config->get('pdns_api', 'key', '');
+        $this->displayName = $config->get('pdns_api', 'display_name', '');
         $this->serverName = $config->get('pdns_api', 'server_name', 'localhost');
         $this->apiEnabled = !empty($this->apiUrl) && !empty($this->apiKey);
 
@@ -126,6 +128,7 @@ class PowerdnsStatusService
                 'daemon_type' => $serverInfo['daemon_type'] ?? 'unknown',
                 'version' => $serverInfo['version'] ?? 'unknown',
                 'configured' => true,
+                'display_name' => $this->displayName,
                 'server_name' => $this->serverName,
                 'id' => $serverInfo['id'] ?? $this->serverName,
                 'metrics' => $metrics,

--- a/templates/default/index.html
+++ b/templates/default/index.html
@@ -20,7 +20,7 @@
                 {% endif %}
             </div>
             <div class="card-body d-flex flex-column justify-content-between">
-                <h6 class="card-title text-center text-truncate d-none d-md-block">{% trans %}PowerDNS Status{% endtrans %}</h6>
+                <h6 class="card-title text-center text-truncate d-none d-md-block">{{ pdns_server_status.display }}</h6>
                 <p class="card-text small text-muted text-center d-none d-lg-block">
                     {% if pdns_server_status is defined and pdns_server_status.running %}
                         {% trans %}Server running{% endtrans %} v{{ pdns_server_status.version }}

--- a/templates/default/pdns_status.html
+++ b/templates/default/pdns_status.html
@@ -55,6 +55,10 @@
                         <table class="table table-hover">
                             <tbody>
                                 <tr>
+                                    <th scope="row">{% trans %}PDNS Server{% endtrans %}</th>
+                                    <td>{{ server_status.display_name }}</td>
+                                </tr>
+                                <tr>
                                     <th scope="row">{% trans %}Server Name{% endtrans %}</th>
                                     <td>{{ server_status.server_name }}</td>
                                 </tr>


### PR DESCRIPTION
…display_name' in index overview and PDNS status.

This is just a suggestion. It may be useful for users, that use poweradmin on two or more PowerDNS servers.

Regards,
Michael