### PR TITLE
Fix missing mysql cli in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN apk add --no-cache --virtual .build-deps \
     sqlite \
     openssl \
     bash \
+    mariadb-client \
     postgresql15-client \
     postgresql15-dev \
     libpq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN apk add --no-cache --virtual .build-deps \
     openssl \
     bash \
     mariadb-client \
+    mariadb-connector-c \
     postgresql15-client \
     postgresql15-dev \
     libpq \


### PR DESCRIPTION
MySQL client is needed to create the inital admin user.

Should fix #741 