### PR TITLE
Add check for empty type

### DIFF
--- a/lib/Domain/Repository/RecordRepository.php
+++ b/lib/Domain/Repository/RecordRepository.php
@@ -446,7 +446,10 @@ class RecordRepository implements RecordRepositoryInterface
         $records = [];
 
         while ($record = $stmt->fetch()) {
-            $records[] = $record;
+            if($record['type'] != "")
+            {
+                $records[] = $record;
+            }
         }
 
         return $records;


### PR DESCRIPTION
Hi, i would like to add this check. There is some PowerDNS issue because it creates some empty records without type and content.
when searching by keyword this record seems to appear and make issues (HTTP error 500) when updating some other record.
reference to my feature request #758
I tested it and it seems to work fine.