### PR TITLE
fix(docker): update OIDC Azure AD configuration and metadata URL handling

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -292,7 +292,6 @@ docker run -d --name poweradmin -p 80:80 \
 | `PA_OIDC_AUTO_PROVISION` | Automatically create user accounts from OIDC | `true` | No |
 | `PA_OIDC_LINK_BY_EMAIL` | Link OIDC accounts to existing users by email | `true` | No |
 | `PA_OIDC_SYNC_USER_INFO` | Sync user information from OIDC provider | `true` | No |
-| `PA_OIDC_DEFAULT_PERMISSION_TEMPLATE` | Default permission template for new OIDC users | `Administrator` | No |
 
 ### OIDC Azure AD Provider
 
@@ -303,9 +302,21 @@ docker run -d --name poweradmin -p 80:80 \
 | `PA_OIDC_AZURE_DISPLAY_NAME` | Display name for login button | `Sign in with Microsoft` | No |
 | `PA_OIDC_AZURE_CLIENT_ID` | Application (client) ID from Azure | Empty | Yes if Azure enabled |
 | `PA_OIDC_AZURE_CLIENT_SECRET` | Client secret from Azure | Empty | Yes if Azure enabled |
-| `PA_OIDC_AZURE_TENANT` | Tenant ID or 'common' for multi-tenant | `common` | No |
+| `PA_OIDC_AZURE_TENANT` | Tenant ID, domain, or 'common' for multi-tenant | `common` | No |
 | `PA_OIDC_AZURE_AUTO_DISCOVERY` | Use auto-discovery | `true` | No |
-| `PA_OIDC_AZURE_METADATA_URL` | Metadata URL for discovery | Azure's standard URL | No |
+| `PA_OIDC_AZURE_METADATA_URL` | Custom metadata URL (auto-generated if not provided) | `https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid_configuration` | No |
+
+**Azure AD Configuration Notes:**
+
+- **Tenant ID Format**: Use your Azure tenant ID (GUID), custom domain (e.g., `contoso.onmicrosoft.com`), or `common` for multi-tenant applications
+- **Metadata URL**: Automatically constructed as `https://login.microsoftonline.com/{PA_OIDC_AZURE_TENANT}/v2.0/.well-known/openid_configuration` if not explicitly provided
+- **Scopes**: The container automatically requests `openid profile email` scopes from Azure AD v2.0 endpoint
+- **App Registration**: Ensure your Azure app registration has the correct redirect URI and API permissions (`openid`, `profile`, `email`)
+
+**Example Tenant Values:**
+- Tenant ID: `12345678-1234-1234-1234-123456789012`
+- Custom domain: `contoso.onmicrosoft.com`
+- Multi-tenant: `common`
 
 ### Admin User Creation
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -292,6 +292,9 @@ docker run -d --name poweradmin -p 80:80 \
 | `PA_OIDC_AUTO_PROVISION` | Automatically create user accounts from OIDC | `true` | No |
 | `PA_OIDC_LINK_BY_EMAIL` | Link OIDC accounts to existing users by email | `true` | No |
 | `PA_OIDC_SYNC_USER_INFO` | Sync user information from OIDC provider | `true` | No |
+| `PA_OIDC_DEFAULT_PERMISSION_TEMPLATE` | Default permission template for new OIDC users | `Administrator` | No |
+
+
 
 ### OIDC Azure AD Provider
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -304,12 +304,12 @@ docker run -d --name poweradmin -p 80:80 \
 | `PA_OIDC_AZURE_CLIENT_SECRET` | Client secret from Azure | Empty | Yes if Azure enabled |
 | `PA_OIDC_AZURE_TENANT` | Tenant ID, domain, or 'common' for multi-tenant | `common` | No |
 | `PA_OIDC_AZURE_AUTO_DISCOVERY` | Use auto-discovery | `true` | No |
-| `PA_OIDC_AZURE_METADATA_URL` | Custom metadata URL (auto-generated if not provided) | `https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid_configuration` | No |
+| `PA_OIDC_AZURE_METADATA_URL` | Custom metadata URL (auto-generated if not provided) | `https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration` | No |
 
 **Azure AD Configuration Notes:**
 
 - **Tenant ID Format**: Use your Azure tenant ID (GUID), custom domain (e.g., `contoso.onmicrosoft.com`), or `common` for multi-tenant applications
-- **Metadata URL**: Automatically constructed as `https://login.microsoftonline.com/{PA_OIDC_AZURE_TENANT}/v2.0/.well-known/openid_configuration` if not explicitly provided
+- **Metadata URL**: Automatically constructed as `https://login.microsoftonline.com/{PA_OIDC_AZURE_TENANT}/v2.0/.well-known/openid-configuration` if not explicitly provided
 - **Scopes**: The container automatically requests `openid profile email` scopes from Azure AD v2.0 endpoint
 - **App Registration**: Ensure your Azure app registration has the correct redirect URI and API permissions (`openid`, `profile`, `email`)
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -292,7 +292,7 @@ docker run -d --name poweradmin -p 80:80 \
 | `PA_OIDC_AUTO_PROVISION` | Automatically create user accounts from OIDC | `true` | No |
 | `PA_OIDC_LINK_BY_EMAIL` | Link OIDC accounts to existing users by email | `true` | No |
 | `PA_OIDC_SYNC_USER_INFO` | Sync user information from OIDC provider | `true` | No |
-| `PA_OIDC_DEFAULT_PERMISSION_TEMPLATE` | Default permission template for new OIDC users | `Administrator` | No |
+| `PA_OIDC_DEFAULT_PERMISSION_TEMPLATE` | Default permission template for new OIDC users | Empty | No |
 
 
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -315,11 +315,17 @@ docker run -d --name poweradmin -p 80:80 \
 - **Metadata URL**: Automatically constructed as `https://login.microsoftonline.com/{PA_OIDC_AZURE_TENANT}/v2.0/.well-known/openid-configuration` if not explicitly provided
 - **Scopes**: The container automatically requests `openid profile email` scopes from Azure AD v2.0 endpoint
 - **App Registration**: Ensure your Azure app registration has the correct redirect URI and API permissions (`openid`, `profile`, `email`)
+- **Redirect URI**: Set the redirect URI in your Azure app registration to match your Poweradmin deployment (e.g., `https://poweradmin.yourdomain.com/oidc/callback`)
 
 **Example Tenant Values:**
 - Tenant ID: `12345678-1234-1234-1234-123456789012`
 - Custom domain: `contoso.onmicrosoft.com`
 - Multi-tenant: `common`
+
+**Example Redirect URIs:**
+- Production: `https://poweradmin.yourdomain.com/oidc/callback`
+- Development: `http://localhost:8080/oidc/callback`
+- Subdirectory: `https://yourdomain.com/poweradmin/oidc/callback`
 
 ### Admin User Creation
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -464,7 +464,7 @@ return [
         'auto_provision' => ${oidc_auto_provision},
         'link_by_email' => ${oidc_link_by_email},
         'sync_user_info' => ${oidc_sync_user_info},
-        'default_permission_template' => '${PA_OIDC_DEFAULT_PERMISSION_TEMPLATE:-Administrator}',
+        'default_permission_template' => '${PA_OIDC_DEFAULT_PERMISSION_TEMPLATE:-}',
         'providers' => [
 EOF
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -464,34 +464,36 @@ return [
         'auto_provision' => ${oidc_auto_provision},
         'link_by_email' => ${oidc_link_by_email},
         'sync_user_info' => ${oidc_sync_user_info},
-        'default_permission_template' => '${PA_OIDC_DEFAULT_PERMISSION_TEMPLATE:-Administrator}',
-        'permission_template_mapping' => [
-            'poweradmin-admins' => 'Administrator',
-            'dns-operators' => 'DNS Operator',
-            'dns-viewers' => 'Read Only',
-        ],
+        'default_permission_template' => 'Administrator',
         'providers' => [
 EOF
 
     # Add Azure configuration if enabled
     if [ "${oidc_azure_enabled}" = "true" ]; then
+        # Build the metadata URL with the actual tenant value
+        local azure_metadata_url="${PA_OIDC_AZURE_METADATA_URL:-}"
+        if [ -z "${azure_metadata_url}" ]; then
+            azure_metadata_url="https://login.microsoftonline.com/${PA_OIDC_AZURE_TENANT:-common}/v2.0/.well-known/openid_configuration"
+        fi
+
         cat >> "${CONFIG_FILE}" << EOF
             'azure' => [
-                'name' => 'Microsoft Azure AD',
-                'display_name' => 'Sign in with Microsoft',
+                'name' => '${PA_OIDC_AZURE_NAME:-Microsoft Azure AD}',
+                'display_name' => '${PA_OIDC_AZURE_DISPLAY_NAME:-Sign in with Microsoft}',
                 'client_id' => '${PA_OIDC_AZURE_CLIENT_ID:-}',
                 'client_secret' => '${PA_OIDC_AZURE_CLIENT_SECRET:-}',
                 'tenant' => '${PA_OIDC_AZURE_TENANT:-common}',
                 'auto_discovery' => ${oidc_azure_auto_discovery},
-                'metadata_url' => '${PA_OIDC_AZURE_METADATA_URL:-https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid_configuration}',
+                'metadata_url' => '${azure_metadata_url}',
                 'scopes' => 'openid profile email',
                 'user_mapping' => [
-                    'username' => 'preferred_username',
+                    'username' => 'email',
                     'email' => 'email',
                     'first_name' => 'given_name',
                     'last_name' => 'family_name',
                     'display_name' => 'name',
                     'groups' => 'groups',
+                    'subject' => 'sub',
                 ],
             ],
 EOF

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -473,7 +473,7 @@ EOF
         # Build the metadata URL with the actual tenant value
         local azure_metadata_url="${PA_OIDC_AZURE_METADATA_URL:-}"
         if [ -z "${azure_metadata_url}" ]; then
-            azure_metadata_url="https://login.microsoftonline.com/${PA_OIDC_AZURE_TENANT:-common}/v2.0/.well-known/openid_configuration"
+            azure_metadata_url="https://login.microsoftonline.com/${PA_OIDC_AZURE_TENANT:-common}/v2.0/.well-known/openid-configuration"
         fi
 
         cat >> "${CONFIG_FILE}" << EOF

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -464,7 +464,7 @@ return [
         'auto_provision' => ${oidc_auto_provision},
         'link_by_email' => ${oidc_link_by_email},
         'sync_user_info' => ${oidc_sync_user_info},
-        'default_permission_template' => 'Administrator',
+        'default_permission_template' => '${PA_OIDC_DEFAULT_PERMISSION_TEMPLATE:-Administrator}',
         'providers' => [
 EOF
 


### PR DESCRIPTION
This pull request updates the OIDC Azure AD integration documentation and configuration logic to clarify tenant and metadata URL usage, improve configuration flexibility, and enhance user mapping. It also removes some legacy permission template mapping logic.

**OIDC Azure AD Configuration Improvements:**

* Updated the `DOCKER.md` documentation for `PA_OIDC_AZURE_TENANT` to clarify that it accepts tenant ID, domain, or 'common', and for `PA_OIDC_AZURE_METADATA_URL` to specify that it is auto-generated if not provided. Added detailed configuration notes and example tenant values for better user guidance.
* In `docker-entrypoint.sh`, the Azure metadata URL is now dynamically constructed using the actual tenant value if not explicitly set, ensuring correct endpoint configuration.

**User Mapping and Permission Template Changes:**

* Updated the Azure user mapping to use `email` for the username and added the `subject` (`sub`) field for improved identity tracking.
* Removed the `permission_template_mapping` and the environment variable override for `default_permission_template`, simplifying the permission template logic. [[1]](diffhunk://#diff-79738685a656fe6b25061bb14181442210b599f746faeaba408a2401de45038aL467-R496) [[2]](diffhunk://#diff-972512ed94fce217ace10a2303390c321d822f967f2f008c353fb5f57152b7d0L295)