### PR TITLE
Refactors conditional checks to fix config generation from variables

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,19 +20,19 @@ process_secret_files() {
         VAR_NAME_FILE="${VAR_NAME}__FILE"
 
         # Check if both regular and __FILE versions are set (they are exclusive)
-        [ "${!VAR_NAME}" ] && {
+        if [ "${!VAR_NAME}" ]; then
             log "ERROR: Both ${VAR_NAME} and ${VAR_NAME_FILE} are set but are exclusive"
             exit 1
-        }
+        fi
 
         VAR_FILENAME="${!VAR_NAME_FILE}"
         log "Getting secret ${VAR_NAME} from ${VAR_FILENAME}"
 
         # Validate the secret file exists and is readable
-        [ ! -r "${VAR_FILENAME}" ] && {
+        if [ ! -r "${VAR_FILENAME}" ]; then
             log "ERROR: ${VAR_FILENAME} does not exist or is not readable"
             exit 1
-        }
+        fi
 
         # Read the secret file content and export as environment variable
         export "${VAR_NAME}"="$(<"${VAR_FILENAME}")"
@@ -76,10 +76,10 @@ init_sqlite_db() {
 
 # Validate required database configuration
 validate_database_config() {
-    [ -z "${DB_TYPE}" ] && {
+    if [ -z "${DB_TYPE}" ]; then
         log "ERROR: DB_TYPE environment variable is required. Supported types: sqlite, mysql, pgsql"
         exit 1
-    }
+    fi
     debug_log "Starting database validation with DB_TYPE=${DB_TYPE}"
     case "${DB_TYPE}" in
         "sqlite")
@@ -87,25 +87,25 @@ validate_database_config() {
             debug_log "Checking SQLite database file: ${db_file}"
             debug_log "File exists check: [ -f ${db_file} ] = $([ -f "${db_file}" ] && echo true || echo false)"
             debug_log "Directory writable check: [ -w $(dirname ${db_file}) ] = $([ -w "$(dirname "${db_file}")" ] && echo true || echo false)"
-            [ ! -f "${db_file}" ] && [ ! -w "$(dirname "${db_file}")" ] && {
+            if [ ! -f "${db_file}" ] && [ ! -w "$(dirname "${db_file}")" ]; then
                 log "ERROR: SQLite database file ${db_file} doesn't exist and directory is not writable"
                 exit 1
-            }
+            fi
             debug_log "SQLite validation passed"
             ;;
         "mysql"|"pgsql")
-            [ -z "${DB_HOST}" ] && {
+            if [ -z "${DB_HOST}" ]; then
                 log "ERROR: DB_HOST is required for ${DB_TYPE} database"
                 exit 1
-            }
-            [ -z "${DB_USER}" ] && {
+            fi
+            if [ -z "${DB_USER}" ]; then
                 log "ERROR: DB_USER is required for ${DB_TYPE} database"
                 exit 1
-            }
-            [ -z "${DB_NAME}" ] && {
+            fi
+            if [ -z "${DB_NAME}" ]; then
                 log "ERROR: DB_NAME is required for ${DB_TYPE} database"
                 exit 1
-            }
+            fi
             ;;
         *)
             log "ERROR: Unsupported database type: ${DB_TYPE}. Supported types: sqlite, mysql, pgsql"
@@ -120,18 +120,18 @@ validate_dns_config() {
     debug_log "DNS_NS1='${DNS_NS1}'"
     debug_log "DNS_NS2='${DNS_NS2}'"
     debug_log "DNS_HOSTMASTER='${DNS_HOSTMASTER}'"
-    [ -z "${DNS_NS1}" ] && {
+    if [ -z "${DNS_NS1}" ]; then
         log "WARNING: DNS_NS1 not set, using default: ns1.example.com"
         DNS_NS1="ns1.example.com"
-    }
-    [ -z "${DNS_NS2}" ] && {
+    fi
+    if [ -z "${DNS_NS2}" ]; then
         log "WARNING: DNS_NS2 not set, using default: ns2.example.com"
         DNS_NS2="ns2.example.com"
-    }
-    [ -z "${DNS_HOSTMASTER}" ] && {
+    fi
+    if [ -z "${DNS_HOSTMASTER}" ]; then
         log "WARNING: DNS_HOSTMASTER not set, using default: hostmaster@example.com"
         DNS_HOSTMASTER="hostmaster@example.com"
-    }
+    fi
     debug_log "DNS validation completed"
 }
 
@@ -139,14 +139,14 @@ validate_dns_config() {
 validate_mail_config() {
     local mail_enabled=$(echo "${PA_MAIL_ENABLED:-true}" | tr '[:upper:]' '[:lower:]')
     if [ "$mail_enabled" = "true" ] && [ "${PA_MAIL_TRANSPORT}" = "smtp" ]; then
-        [ -z "${PA_SMTP_HOST}" ] && {
+        if [ -z "${PA_SMTP_HOST}" ]; then
             log "ERROR: PA_SMTP_HOST is required when using SMTP transport"
             exit 1
-        }
-        [ -z "${PA_MAIL_FROM}" ] && {
+        fi
+        if [ -z "${PA_MAIL_FROM}" ]; then
             log "ERROR: PA_MAIL_FROM is required when mail is enabled"
             exit 1
-        }
+        fi
     fi
 }
 
@@ -167,10 +167,10 @@ validate_ldap_config() {
     if [ "$ldap_enabled" = "true" ]; then
         local required_ldap_vars=("PA_LDAP_URI" "PA_LDAP_BASE_DN")
         for var in "${required_ldap_vars[@]}"; do
-            [ -z "${!var}" ] && {
+            if [ -z "${!var}" ]; then
                 log "ERROR: ${var} is required when LDAP is enabled"
                 exit 1
-            }
+            fi
         done
     fi
 }
@@ -193,20 +193,20 @@ validate_saml_config() {
 
         # Validate Azure SAML configuration if enabled
         if [ "$azure_enabled" = "true" ]; then
-            [ -z "${PA_SAML_AZURE_X509_CERT}" ] && {
+            if [ -z "${PA_SAML_AZURE_X509_CERT}" ]; then
                 log "ERROR: PA_SAML_AZURE_X509_CERT is required when Azure SAML is enabled"
                 exit 1
-            }
+            fi
         fi
 
         # Validate Okta SAML configuration if enabled
         if [ "$okta_enabled" = "true" ]; then
             local required_okta_vars=("PA_SAML_OKTA_ENTITY_ID" "PA_SAML_OKTA_SSO_URL" "PA_SAML_OKTA_X509_CERT")
             for var in "${required_okta_vars[@]}"; do
-                [ -z "${!var}" ] && {
+                if [ -z "${!var}" ]; then
                     log "ERROR: ${var} is required when Okta SAML is enabled"
                     exit 1
-                }
+                fi
             done
         fi
 
@@ -214,10 +214,10 @@ validate_saml_config() {
         if [ "$auth0_enabled" = "true" ]; then
             local required_auth0_vars=("PA_SAML_AUTH0_ENTITY_ID" "PA_SAML_AUTH0_SSO_URL" "PA_SAML_AUTH0_X509_CERT")
             for var in "${required_auth0_vars[@]}"; do
-                [ -z "${!var}" ] && {
+                if [ -z "${!var}" ]; then
                     log "ERROR: ${var} is required when Auth0 SAML is enabled"
                     exit 1
-                }
+                fi
             done
         fi
 
@@ -225,10 +225,10 @@ validate_saml_config() {
         if [ "$keycloak_enabled" = "true" ]; then
             local required_keycloak_vars=("PA_SAML_KEYCLOAK_ENTITY_ID" "PA_SAML_KEYCLOAK_SSO_URL" "PA_SAML_KEYCLOAK_X509_CERT")
             for var in "${required_keycloak_vars[@]}"; do
-                [ -z "${!var}" ] && {
+                if [ -z "${!var}" ]; then
                     log "ERROR: ${var} is required when Keycloak SAML is enabled"
                     exit 1
-                }
+                fi
             done
         fi
 
@@ -236,10 +236,10 @@ validate_saml_config() {
         if [ "$generic_enabled" = "true" ]; then
             local required_generic_vars=("PA_SAML_GENERIC_ENTITY_ID" "PA_SAML_GENERIC_SSO_URL" "PA_SAML_GENERIC_X509_CERT")
             for var in "${required_generic_vars[@]}"; do
-                [ -z "${!var}" ] && {
+                if [ -z "${!var}" ]; then
                     log "ERROR: ${var} is required when Generic SAML is enabled"
                     exit 1
-                }
+                fi
             done
         fi
     fi


### PR DESCRIPTION
Hi!
While testing the application’s functionality, I encountered an error in the functions responsible for validating the provided variables in docker-entrypoint.sh.

---

For example in `validate_mail_config` function:

Original code:
``` bash
#!/bin/bash

set -x

validate_mail_config() {
    local mail_enabled=$(echo "${PA_MAIL_ENABLED:-true}" | tr '[:upper:]' '[:lower:]')
    if [ "$mail_enabled" = "true" ] && [ "${PA_MAIL_TRANSPORT}" = "smtp" ]; then
        [ -z "${PA_SMTP_HOST}" ] && {
            log "ERROR: PA_SMTP_HOST is required when using SMTP transport"
            exit 1
        }
        [ -z "${PA_MAIL_FROM}" ] && {
            log "ERROR: PA_MAIL_FROM is required when mail is enabled"
            exit 1
        }
    fi
}

PA_MAIL_ENABLED=true
PA_MAIL_TRANSPORT=smtp
PA_SMTP_HOST=example.com
PA_MAIL_FROM=example.com

validate_mail_config

echo "Exit code: ${?}"
```

Execute:
``` bash
+ PA_MAIL_ENABLED=true
+ PA_MAIL_TRANSPORT=smtp
+ PA_SMTP_HOST=example.com
+ PA_MAIL_FROM=example.com
+ validate_mail_config
++ echo true
++ tr '[:upper:]' '[:lower:]'
+ local mail_enabled=true
+ '[' true = true ']'
+ '[' smtp = smtp ']'
+ '[' -z example.com ']'
+ '[' -z example.com ']'
+ echo 'Exit code: 1'
Exit code: 1
```

Even if all required variables are there function will return 1 and container will exit…

Fixed code:
``` bash
#!/bin/bash

set -x

validate_mail_config() {
    local mail_enabled=$(echo "${PA_MAIL_ENABLED:-true}" | tr '[:upper:]' '[:lower:]')
    if [ "$mail_enabled" = "true" ] && [ "${PA_MAIL_TRANSPORT}" = "smtp" ]; then
        if [ -z "${PA_SMTP_HOST}" ]; then
            log "ERROR: PA_SMTP_HOST is required when using SMTP transport"
            exit 1
        fi
        if [ -z "${PA_MAIL_FROM}" ]; then
            log "ERROR: PA_MAIL_FROM is required when mail is enabled"
            exit 1
        fi
    fi
}

PA_MAIL_ENABLED=true
PA_MAIL_TRANSPORT=smtp
PA_SMTP_HOST=example.com
PA_MAIL_FROM=example.com

validate_mail_config

echo "Exit code: ${?}"
```

Execute:
``` bash
+ PA_MAIL_ENABLED=true
+ PA_MAIL_TRANSPORT=smtp
+ PA_SMTP_HOST=example.com
+ PA_MAIL_FROM=example.com
+ validate_mail_config
++ echo true
++ tr '[:upper:]' '[:lower:]'
+ local mail_enabled=true
+ '[' true = true ']'
+ '[' smtp = smtp ']'
+ '[' -z example.com ']'
+ '[' -z example.com ']'
+ echo 'Exit code: 0'
Exit code: 0
```

---

Some functions like for example `validate_dns_config` have `debug_log` function executed at the end which changes the incorrect exit code 1 to 0.