### PR TITLE
docs: fix broken screenshot URLs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,19 +38,19 @@ DNSSEC operations.
 
 ### Login Screen
 
-![Login interface with multi-language and MFA support](https://docs.poweradmin.org/screenshots/light_login.png)
+![Login interface with multi-language and MFA support](https://docs.poweradmin.org/screenshots/theme-light.png)
 
 ### Dashboard
 
-![Dashboard with quick actions and navigation](https://docs.poweradmin.org/screenshots/light_index_page.png)
+![Dashboard with quick actions and navigation](https://docs.poweradmin.org/screenshots/dashboard.png)
 
 ### Zone Management
 
-![Zone list with sorting and filtering](https://docs.poweradmin.org/screenshots/light_zone_list.png)
+![Zone list with sorting and filtering](https://docs.poweradmin.org/screenshots/zone-list.png)
 
 ### Zone Editor
 
-![Zone editor with inline record management](https://docs.poweradmin.org/screenshots/light_zone_edit.png)
+![Zone editor with inline record management](https://docs.poweradmin.org/screenshots/zone-editor.png)
 
 ### Zone Metadata Editor
 


### PR DESCRIPTION
The screenshot URLs in the README pointed to files that no longer exist on docs.poweradmin.org (404). Updated them to the correct filenames currently available:\n\n- `light_login.png` → `theme-light.png`\n- `light_index_page.png` → `dashboard.png`\n- `light_zone_list.png` → `zone-list.png`\n- `light_zone_edit.png` → `zone-editor.png`