### PR TITLE
feat(zones): populate PowerDNS account field with oldest zone owner

### DIFF
--- a/lib/Domain/Service/Dns/DomainManager.php
+++ b/lib/Domain/Service/Dns/DomainManager.php
@@ -155,6 +155,11 @@ class DomainManager implements DomainManagerInterface
                         $zone_id = $db->lastInsertId();
                     }
 
+                    $account = self::getZoneAccount($db, $domain_id);
+                    if ($account !== null) {
+                        $this->backendProvider->updateZoneAccount($domain_id, $account);
+                    }
+
                     // Create sync tracking record if using a template
                     if ($zone_template != "none" && is_numeric($zone_template)) {
                         $syncService = new ZoneTemplateSyncService($db, $this->config, $this->backendProvider);
@@ -547,6 +552,11 @@ class DomainManager implements DomainManagerInterface
                     }
                     $stmt = $db->prepare("INSERT INTO zones (domain_id, owner, zone_templ_id) VALUES(?, ?, ?)");
                     $stmt->execute([$zone_id, $user_id, $zone_templ_id]);
+
+                    $account = self::getZoneAccount($db, $zone_id);
+                    if ($account !== null) {
+                        $this->backendProvider->updateZoneAccount($zone_id, $account);
+                    }
                     return true;
                 } else {
                     $messageService = new MessageService();
@@ -580,6 +590,11 @@ class DomainManager implements DomainManagerInterface
                 if ($stmt->fetchColumn() > 1) {
                     $stmt = $db->prepare("DELETE FROM zones WHERE owner = ? AND domain_id = ?");
                     $stmt->execute([$user_id, $zone_id]);
+
+                    $account = self::getZoneAccount($db, $zone_id);
+                    if ($account !== null) {
+                        $this->backendProvider->updateZoneAccount($zone_id, $account);
+                    }
                     return true;
                 } else {
                     $messageService = new MessageService();
@@ -840,5 +855,19 @@ class DomainManager implements DomainManagerInterface
     private static function isIpv4ReverseZone(string $domain): bool
     {
         return stripos($domain, 'in-addr.arpa') !== false;
+    }
+
+    private static function getZoneAccount(PDO $db, int $domainId): ?string
+    {
+        $stmt = $db->prepare("
+            SELECT u.username
+            FROM users u
+            INNER JOIN zones z ON z.owner = u.id
+            WHERE z.domain_id = ?
+            ORDER BY z.id
+            LIMIT 1
+        ");
+        $stmt->execute([$domainId]);
+        return $stmt->fetchColumn();
     }
 }

--- a/lib/Infrastructure/Repository/ApiZoneRepository.php
+++ b/lib/Infrastructure/Repository/ApiZoneRepository.php
@@ -650,14 +650,20 @@ class ApiZoneRepository implements ZoneRepositoryInterface
         if ($canonical === null) {
             return false;
         }
+        $cid = (int)$canonical['id'];
+
         $stmt = $this->db->prepare(
             "INSERT INTO zones (domain_id, owner, zone_templ_id)
              VALUES (:domain_id, :owner, :zone_templ_id)"
         );
-        $stmt->bindValue(':domain_id', (int)$canonical['id'], PDO::PARAM_INT);
+        $stmt->bindValue(':domain_id', $cid, PDO::PARAM_INT);
         $stmt->bindValue(':owner', $userId, PDO::PARAM_INT);
         $stmt->bindValue(':zone_templ_id', (int)($canonical['zone_templ_id'] ?? 0), PDO::PARAM_INT);
         $stmt->execute();
+        $account = self::getZoneAccount($this->db, $cid);
+        if ($account !== null) {
+            $this->backendProvider->updateZoneAccount($cid, $account);
+        }
         return $stmt->rowCount() > 0;
     }
 
@@ -677,7 +683,10 @@ class ApiZoneRepository implements ZoneRepositoryInterface
         $stmt->bindValue(':cid', $cid, PDO::PARAM_INT);
         $stmt->bindValue(':owner', $userId, PDO::PARAM_INT);
         $stmt->execute();
-
+        $account = self::getZoneAccount($this->db, $cid);
+        if ($account !== null) {
+            $this->backendProvider->updateZoneAccount($cid, $account);
+        }
         if ($stmt->rowCount() > 0) {
             return true;
         }
@@ -689,6 +698,10 @@ class ApiZoneRepository implements ZoneRepositoryInterface
         $stmt->bindValue(':id', $cid, PDO::PARAM_INT);
         $stmt->bindValue(':owner', $userId, PDO::PARAM_INT);
         $stmt->execute();
+        $account = self::getZoneAccount($this->db, $cid);
+        if ($account !== null) {
+            $this->backendProvider->updateZoneAccount($cid, $account);
+        }
         return $stmt->rowCount() > 0;
     }
 
@@ -955,5 +968,19 @@ class ApiZoneRepository implements ZoneRepositoryInterface
     {
         // TODO: Implement via PowerDNS API metadata endpoints
         return false;
+    }
+
+    private static function getZoneAccount(PDO $db, int $domainId): ?string
+    {
+        $stmt = $db->prepare("
+            SELECT u.username
+            FROM users u
+            INNER JOIN zones z ON z.owner = u.id
+            WHERE z.domain_id = ?
+            ORDER BY z.id
+            LIMIT 1
+        ");
+        $stmt->execute([$domainId]);
+        return $stmt->fetchColumn();
     }
 }

--- a/lib/Infrastructure/Repository/DbZoneRepository.php
+++ b/lib/Infrastructure/Repository/DbZoneRepository.php
@@ -892,7 +892,10 @@ class DbZoneRepository implements ZoneRepositoryInterface
         $stmt->bindValue(':owner', $userId, PDO::PARAM_INT);
         $stmt->bindValue(':zone_templ_id', $zoneTemplId, PDO::PARAM_INT);
         $stmt->execute();
-
+        $account = self::getZoneAccount($this->db, $zoneId);
+        if ($account !== null) {
+            $this->backendProvider->updateZoneAccount($zoneId, $account);
+        }
         return $stmt->rowCount() > 0;
     }
 
@@ -911,7 +914,10 @@ class DbZoneRepository implements ZoneRepositoryInterface
         $stmt->bindValue(':domain_id', $zoneId, PDO::PARAM_INT);
         $stmt->bindValue(':owner', $userId, PDO::PARAM_INT);
         $stmt->execute();
-
+        $account = self::getZoneAccount($this->db, $zoneId);
+        if ($account !== null) {
+            $this->backendProvider->updateZoneAccount($zoneId, $account);
+        }
         return $stmt->rowCount() > 0;
     }
 
@@ -1335,5 +1341,19 @@ class DbZoneRepository implements ZoneRepositoryInterface
 
         $result = $stmt->fetch(PDO::FETCH_ASSOC);
         return $result ?: null;
+    }
+
+    private static function getZoneAccount(PDO $db, int $domainId): ?string
+    {
+        $stmt = $db->prepare("
+            SELECT u.username
+            FROM users u
+            INNER JOIN zones z ON z.owner = u.id
+            WHERE z.domain_id = ?
+            ORDER BY z.id
+            LIMIT 1
+        ");
+        $stmt->execute([$domainId]);
+        return $stmt->fetchColumn();
     }
 }


### PR DESCRIPTION
This is a "rough" pull request to implement populating zones "account" field in PowerDNS with the zone owner login name in Poweradmin (see issue #1358).

When multiple owners are defined for a zone in Poweradmin, the oldest owner is used.

Unfortunately, the `getZoneAccount()` function, used to determine the owner login name to use as account in PowerDNS, is identically declared as a static function in three different places.

I would welcome any idea to improve on this Q&D implementation, which works but is not exactly elegant...