### PR TITLE
Fix multiple secondary master IPs in API backend

### DIFF
--- a/lib/Infrastructure/Service/ApiDnsBackendProvider.php
+++ b/lib/Infrastructure/Service/ApiDnsBackendProvider.php
@@ -59,6 +59,16 @@ class ApiDnsBackendProvider implements DnsBackendProvider
     // Zone operations
     // ---------------------------------------------------------------
 
+    private static function parseMasters(string $masters): array
+    {
+        return array_values(
+            array_filter(
+                array_map('trim', explode(',', $masters)),
+                static fn(string $master): bool => $master !== ''
+            )
+        );
+    }
+    
     public function createZone(string $domain, string $type, string $slaveMaster = ''): int|false
     {
         $apiName = self::ensureTrailingDot($domain);
@@ -70,7 +80,7 @@ class ApiDnsBackendProvider implements DnsBackendProvider
         ];
 
         if ($type === 'SLAVE' && $slaveMaster !== '') {
-            $zoneData['masters'] = [$slaveMaster];
+            $zoneData['masters'] = self::parseMasters($slaveMaster);
         }
 
         $result = $this->client->createZoneWithData($zoneData);
@@ -155,7 +165,10 @@ class ApiDnsBackendProvider implements DnsBackendProvider
         }
 
         $apiName = self::ensureTrailingDot($zoneName);
-        $result = $this->client->updateZoneProperties($apiName, ['masters' => [$masterIp]]);
+        $result = $this->client->updateZoneProperties(
+            $apiName,
+            ['masters' => self::parseMasters($masterIp)]
+        );
 
         if ($result) {
             $stmt = $this->db->prepare("UPDATE zones SET zone_master = :master WHERE id = :id");

--- a/tests/unit/Infrastructure/Service/ApiDnsBackendProviderTest.php
+++ b/tests/unit/Infrastructure/Service/ApiDnsBackendProviderTest.php
@@ -88,6 +88,35 @@ class ApiDnsBackendProviderTest extends TestCase
         $this->assertEquals(43, $result);
     }
 
+    public function testCreateSlaveZoneIncludesMultipleMasters(): void
+    {
+        $this->mockClient->expects($this->once())
+            ->method('createZoneWithData')
+            ->with([
+                'name' => 'slave.example.com.',
+                'kind' => 'SLAVE',
+                'nameservers' => [],
+                'masters' => [
+                    '192.0.2.1',
+                    '2001:db8::1',
+                ],
+            ])
+            ->willReturn(['name' => 'slave.example.com.']);
+    
+        $stmt = $this->createMock(PDOStatement::class);
+        $stmt->method('execute');
+        $stmt->method('fetchColumn')->willReturn(43);
+        $this->mockDb->method('prepare')->willReturn($stmt);
+    
+        $result = $this->provider->createZone(
+            'slave.example.com',
+            'SLAVE',
+            '192.0.2.1, 2001:db8::1'
+        );
+    
+        $this->assertEquals(43, $result);
+    }
+
     public function testCreateZoneReturnsFalseOnApiFailure(): void
     {
         $this->mockClient->expects($this->once())
@@ -223,6 +252,43 @@ class ApiDnsBackendProviderTest extends TestCase
 
         $result = $this->provider->updateZoneMaster(1, '192.168.1.100');
 
+        $this->assertTrue($result);
+    }
+
+    public function testUpdateZoneMasterHandlesMultipleMasters(): void
+    {
+        $stmt = $this->createMock(PDOStatement::class);
+        $stmt->method('execute');
+        $stmt->method('fetchColumn')->willReturn('slave.example.com');
+        $stmt->method('bindValue');
+    
+        $stmtUpdate = $this->createMock(PDOStatement::class);
+        $stmtUpdate->method('bindValue');
+        $stmtUpdate->method('execute');
+    
+        $this->mockDb->method('prepare')->willReturnOnConsecutiveCalls(
+            $stmt,
+            $stmtUpdate
+        );
+    
+        $this->mockClient->expects($this->once())
+            ->method('updateZoneProperties')
+            ->with(
+                'slave.example.com.',
+                [
+                    'masters' => [
+                        '192.0.2.1',
+                        '2001:db8::1',
+                    ],
+                ]
+            )
+            ->willReturn(true);
+    
+        $result = $this->provider->updateZoneMaster(
+            1,
+            '192.0.2.1, 2001:db8::1'
+        );
+    
         $this->assertTrue($result);
     }
 


### PR DESCRIPTION
## Summary

Fix handling of multiple master IP addresses for secondary zones when using the PowerDNS API backend.

The secondary zone form already accepts comma-separated IPv4/IPv6 master addresses, but `ApiDnsBackendProvider` was passing the entire input as a single element of the PowerDNS `masters` array.

This caused zone creation to fail when more than one master address was configured.

## Changes

* Split and trim comma-separated master addresses before sending them to the PowerDNS API.
* Apply the same handling when updating secondary zone masters.
* Preserve the existing single-master behavior.
* Add unit tests for multiple IPv4/IPv6 masters.

## Example

Input:

```text
192.0.2.1, 2001:db8::1
```

Previously sent as:

```json
{
  "masters": [
    "192.0.2.1, 2001:db8::1"
  ]
}
```

Now sent correctly as:

```json
{
  "masters": [
    "192.0.2.1",
    "2001:db8::1"
  ]
}
```

## Testing

The fix was tested successfully with:

* a single IPv4 master;
* a single IPv6 master;
* combined IPv4 and IPv6 masters;
* a real PowerDNS REST API backend.

The existing single-master behavior remains unchanged.
