### PR TITLE
fix(zones): correct SOA-EDIT-API and TSIG metadata handling

### DIFF
--- a/lib/Application/Controller/EditZoneMetadataController.php
+++ b/lib/Application/Controller/EditZoneMetadataController.php
@@ -231,9 +231,23 @@ class EditZoneMetadataController extends BaseController
         $rows = [];
         foreach ($apiMetadata as $entry) {
             $kind = $entry['kind'] ?? '';
+            
+            // SOA-EDIT-API is also exposed through the zone object and is
+            // handled separately below. Skip the metadata endpoint value
+            // to avoid displaying the same metadata twice.
+            if ($kind === 'SOA-EDIT-API') {
+                continue;
+            }
+            
             foreach (($entry['metadata'] ?? []) as $value) {
                 $rows[] = ['kind' => $kind, 'content' => (string) $value];
             }
+        }
+
+        // Use the zone object's soa_edit_api property as the canonical source.
+        $zoneData = $this->apiClient->getZone($apiName);
+        if ($zoneData !== null && !empty($zoneData['soa_edit_api'])) {
+            $rows[] = ['kind' => 'SOA-EDIT-API', 'content' => $zoneData['soa_edit_api']];
         }
 
         // SOA-EDIT-API is stored on the zone object, not in /metadata

--- a/lib/Domain/Model/MetadataDefinitions.php
+++ b/lib/Domain/Model/MetadataDefinitions.php
@@ -123,9 +123,9 @@ class MetadataDefinitions
         ],
         'TSIG-ALLOW-DNSUPDATE' => [
             'label' => 'TSIG-ALLOW-DNSUPDATE',
-            'multi' => false,
+            'multi' => true,
             'placeholder' => 'update-key-name',
-            'help' => 'TSIG key required for DNS updates.',
+            'help' => 'TSIG keys allowed for DNS updates. Add one key name per row.',
             'api_write' => true,
             'min_version' => '4.0.0',
         ],


### PR DESCRIPTION
## Summary

Fix two issues in the zone metadata editor when using the PowerDNS API backend.

### Duplicate SOA-EDIT-API

PowerDNS exposes `SOA-EDIT-API` through both the zone metadata endpoint and
the zone object's `soa_edit_api` property.

Poweradmin currently reads both sources, causing the same value to appear
twice in the metadata editor.

Since `SOA-EDIT-API` is defined as single-valued, the duplicate rows also
cause validation to fail when saving the metadata form.

This change skips `SOA-EDIT-API` from the generic metadata endpoint results
and uses the zone object's `soa_edit_api` property as the canonical source.

### Multiple TSIG-ALLOW-DNSUPDATE values

PowerDNS supports multiple `TSIG-ALLOW-DNSUPDATE` metadata values, allowing
multiple TSIG keys to be authorized for dynamic DNS updates.

Poweradmin currently defines this metadata kind with `multi => false`,
causing validation to reject zones containing more than one authorized key.

This change marks `TSIG-ALLOW-DNSUPDATE` as multi-valued and updates the
help text accordingly.

## Tested with

- Poweradmin 4.4.0
- PowerDNS Authoritative Server 5.1.4
- PowerDNS API backend

Verified that:

- `SOA-EDIT-API = DEFAULT` is displayed only once.
- Metadata can be saved without the duplicate single-value validation error.
- Multiple `TSIG-ALLOW-DNSUPDATE` values are displayed and can be saved.