### PR TITLE
fix(auth): treat an empty password hash as a failed login

### DIFF
--- a/lib/Application/Service/UserAuthenticationService.php
+++ b/lib/Application/Service/UserAuthenticationService.php
@@ -96,6 +96,12 @@ class UserAuthenticationService
      */
     public function verifyPassword(string $password, string $hash): bool
     {
+        // Users provisioned by LDAP/OIDC/SAML have no local hash. That is a failed
+        // verification, not an unknown algorithm, so it must not throw.
+        if ($hash === '') {
+            return false;
+        }
+
         $hash_type = $this->identifyHashAlgorithm($hash);
 
         if ($hash_type === 'md5salt') {

--- a/lib/Infrastructure/Repository/DbUserRepository.php
+++ b/lib/Infrastructure/Repository/DbUserRepository.php
@@ -485,6 +485,12 @@ class DbUserRepository implements UserRepository
 
         $allowedFields = ['username', 'password', 'fullname', 'email', 'description', 'active', 'perm_templ', 'use_ldap'];
 
+        // An empty password means "leave it unchanged"; callers only hash non-empty
+        // values, so storing it verbatim would replace the hash with an empty string.
+        if (array_key_exists('password', $userData) && (string)$userData['password'] === '') {
+            unset($userData['password']);
+        }
+
         foreach ($allowedFields as $field) {
             if (array_key_exists($field, $userData)) {
                 $setFields[] = "{$field} = :{$field}";

--- a/tests/unit/UserAuthenticationServiceTest.php
+++ b/tests/unit/UserAuthenticationServiceTest.php
@@ -341,4 +341,20 @@ class UserAuthenticationServiceTest extends TestCase
 
         $this->assertTrue($result, 'Password verification should be successful for a unicode password');
     }
+
+    /**
+     * LDAP/OIDC/SAML-provisioned accounts store an empty hash. That must read as a
+     * failed verification rather than throwing, which callers surface as a 500.
+     */
+    public function testVerifyPasswordReturnsFalseForEmptyHash(): void
+    {
+        $this->assertFalse($this->userAuthService->verifyPassword('any-password', ''));
+    }
+
+    public function testVerifyPasswordStillRejectsAnUnknownHashFormat(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->userAuthService->verifyPassword('any-password', 'not-a-recognised-hash');
+    }
 }


### PR DESCRIPTION
Backport of two fixes already on `develop` (also on `release/4.3.x` and `release/4.2.x`).

`UserAuthenticationService::verifyPassword()` throws `InvalidArgumentException('Unable to determine hash algorithm')` when the stored hash is an empty string. Nothing catches it before `index.php`, so every login attempt for such an account returns a 500 rather than a failed login, and `recordAttempt(..., false)` never runs - the attempts are invisible to lockout accounting and the audit log.

Two paths reach that state on this branch:

- `DbUserRepository::updateUser()` builds its SET clause with `array_key_exists`, while the service above it only hashes when the value is non-empty. `{"password": ""}` through the API therefore skips hashing, skips the external-auth refusal, and is written verbatim.
- Unchecking LDAP on a user maps `auth_method` to `sql` without touching `password`, and LDAP-provisioned users are created with an empty hash by design.

The guard already exists twice in the codebase - `BasicAuthenticationMiddleware` and `DynamicDnsAuthenticationService` - so this moves it into `verifyPassword()` where all four callers benefit, including `PasswordChangeService`, which was unguarded.

`release/3.x` is deliberately excluded: it stores an `LDAP_USER` sentinel rather than an empty string, its login query filters `use_ldap=0`, and it has no API v2 user update, so no path reaches the throw.

Verified on this branch: 3431 unit tests, phpcs and `composer compat:8.2` all clean.