### PR TITLE
ci: run twig linting on develop

### DIFF
--- a/.github/workflows/twig-lint.yml
+++ b/.github/workflows/twig-lint.yml
@@ -3,13 +3,13 @@ name: Twig Linting
 on:
   workflow_dispatch:
   push:
-    branches: [ "master", "release/4.2.x", "release/4.3.x" ]
+    branches: [ "master", "develop", "release/4.2.x", "release/4.3.x" ]
     paths:
       - 'templates/**/*.twig'
       - 'templates/**/*.html'
       - '.github/workflows/twig-lint.yml'
   pull_request:
-    branches: [ "master", "release/4.2.x", "release/4.3.x" ]
+    branches: [ "master", "develop", "release/4.2.x", "release/4.3.x" ]
     paths:
       - 'templates/**/*.twig'
       - 'templates/**/*.html'


### PR DESCRIPTION
`twig-lint.yml` targeted only `master` and the two 4.x release branches, so template changes merged into `develop` were never linted. Adds `develop` to both the `push` and `pull_request` trigger lists.

Path filters are unchanged — it still only fires on `templates/**` changes.