### PR TITLE
perf(ci): run phpcs across four workers

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,10 @@
 <ruleset name="Custom PSR-12">
     <description>PSR-12 with modified line length</description>
 
+    <!-- phpcs is single-process by default; the CI runner has 4 cores idle.
+         Splits the ~960-file scan across workers (requires ext-pcntl). -->
+    <arg name="parallel" value="4"/>
+
     <rule ref="PSR12">
         <exclude name="PSR12.Classes.OpeningBraceSpace"/>
     </rule>


### PR DESCRIPTION
`Code Style Check` is the long pole in the validations workflow at ~86s — 2.3x the next-longest job, and it sits on the critical path (`setup` -> `code-style` -> `summary` = ~128s wall).

It runs `phpcs` over ~960 files single-process while the runner has 4 cores idle. Sets `parallel=4` in `phpcs.xml`.

Deliberately not adding `cache`: the runner is ephemeral, so `.phpcs-cache` would be cold every run and buy nothing, and persisting it across runs risks stale results masking violations.