### PR TITLE
perf(ci): remove the setup gate and parallelise the syntax check

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,11 +15,39 @@ permissions:
   contents: read
 
 jobs:
-  setup:
-    name: Setup & Install Dependencies
+  composer-validate:
+    name: Composer Manifest Validation
     runs-on: ubuntu-latest
-    outputs:
-      cache-key: ${{ steps.cache-key.outputs.key }}
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+      with:
+        php-version: '8.4'
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict --check-lock
+
+  syntax-check:
+    name: PHP Syntax Validation
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
+      with:
+        php-version: '8.4'
+
+    - name: Validate PHP syntax
+      run: find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 -P4 php -l
+
+  security-audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -41,62 +69,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-composer-
 
-    - name: Validate composer.json and composer.lock
-      run: composer validate --strict --check-lock
-
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress
 
-    - name: Regenerate autoloader
-      run: composer dump-autoload --no-interaction
-
     - name: Fix vendor binary permissions
       run: chmod +x vendor/bin/*
-
-    - name: Generate cache key
-      id: cache-key
-      run: echo "key=${{ runner.os }}-vendor-${{ hashFiles('**/composer.lock', '**/composer.json') }}" >> $GITHUB_OUTPUT
-
-    - name: Cache vendor directory
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: vendor
-        key: ${{ steps.cache-key.outputs.key }}
-
-  syntax-check:
-    name: PHP Syntax Validation
-    runs-on: ubuntu-latest
-    needs: setup
-
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
-      with:
-        php-version: '8.4'
-
-    - name: Validate PHP syntax
-      run: find . -name "*.php" -not -path "./vendor/*" -print0 | xargs -0 -n1 php -l
-
-  security-audit:
-    name: Security Audit
-    runs-on: ubuntu-latest
-    needs: setup
-
-    steps:
-    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-    - name: Setup PHP
-      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
-      with:
-        php-version: '8.4'
-
-    - name: Restore vendor cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-      with:
-        path: vendor
-        key: ${{ needs.setup.outputs.cache-key }}
 
     - name: Security audit
       run: composer audit
@@ -104,7 +81,6 @@ jobs:
   code-style:
     name: Code Style Check
     runs-on: ubuntu-latest
-    needs: setup
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -114,11 +90,23 @@ jobs:
       with:
         php-version: '8.4'
 
-    - name: Restore vendor cache
+    - name: Get Composer cache directory
+      id: composer-cache-dir
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache Composer dependencies
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: vendor
-        key: ${{ needs.setup.outputs.cache-key }}
+        path: ${{ steps.composer-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Fix vendor binary permissions
+      run: chmod +x vendor/bin/*
 
     - name: Check code style
       run: composer check:all
@@ -126,7 +114,6 @@ jobs:
   phpstan:
     name: PHPStan Analysis
     runs-on: ubuntu-latest
-    needs: setup
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -136,11 +123,23 @@ jobs:
       with:
         php-version: '8.4'
 
-    - name: Restore vendor cache
+    - name: Get Composer cache directory
+      id: composer-cache-dir
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache Composer dependencies
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: vendor
-        key: ${{ needs.setup.outputs.cache-key }}
+        path: ${{ steps.composer-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Fix vendor binary permissions
+      run: chmod +x vendor/bin/*
 
     - name: Run PHPStan analysis
       run: composer analyse:phpstan
@@ -148,7 +147,6 @@ jobs:
   unit-tests:
     name: Unit Tests
     runs-on: ubuntu-latest
-    needs: setup
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -158,11 +156,23 @@ jobs:
       with:
         php-version: '8.4'
 
-    - name: Restore vendor cache
+    - name: Get Composer cache directory
+      id: composer-cache-dir
+      run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+    - name: Cache Composer dependencies
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
-        path: vendor
-        key: ${{ needs.setup.outputs.cache-key }}
+        path: ${{ steps.composer-cache-dir.outputs.dir }}
+        key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-composer-
+
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Fix vendor binary permissions
+      run: chmod +x vendor/bin/*
 
     - name: Run test suite
       run: composer tests
@@ -170,7 +180,6 @@ jobs:
   compatibility:
     name: PHP ${{ matrix.php-version }} Compatibility
     runs-on: ubuntu-latest
-    needs: setup
 
     strategy:
       fail-fast: false
@@ -358,13 +367,14 @@ jobs:
   summary:
     name: Validation Summary
     runs-on: ubuntu-latest
-    needs: [syntax-check, security-audit, code-style, phpstan, unit-tests, compatibility, twig-csrf-check, vendor-check, pin-check, locale-check]
+    needs: [composer-validate, syntax-check, security-audit, code-style, phpstan, unit-tests, compatibility, twig-csrf-check, vendor-check, pin-check, locale-check]
     if: always()
 
     steps:
     - name: Check job statuses
       env:
         RUNNER_OS: ${{ runner.os }}
+        COMPOSER_VALIDATE_RESULT: ${{ needs.composer-validate.result }}
         SYNTAX_RESULT: ${{ needs.syntax-check.result }}
         SECURITY_RESULT: ${{ needs.security-audit.result }}
         CODE_STYLE_RESULT: ${{ needs.code-style.result }}
@@ -384,6 +394,12 @@ jobs:
         echo "**Platform:** $RUNNER_OS" >> "$GITHUB_STEP_SUMMARY"
         echo "" >> "$GITHUB_STEP_SUMMARY"
         echo "**Quality Checks:**" >> "$GITHUB_STEP_SUMMARY"
+
+        if [ "$COMPOSER_VALIDATE_RESULT" = "success" ]; then
+          echo "- ✅ Composer Manifest Validation" >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "- ❌ Composer Manifest Validation" >> "$GITHUB_STEP_SUMMARY"
+        fi
 
         if [ "$SYNTAX_RESULT" = "success" ]; then
           echo "- ✅ PHP Syntax Validation" >> "$GITHUB_STEP_SUMMARY"
@@ -450,6 +466,7 @@ jobs:
 
     - name: Fail if any job failed
       if: |
+        needs.composer-validate.result != 'success' ||
         needs.syntax-check.result != 'success' ||
         needs.security-audit.result != 'success' ||
         needs.code-style.result != 'success' ||


### PR DESCRIPTION
The `setup` job built `vendor`, cached it, and six jobs waited on it — about 36s of serialization before any real work started.

The `compatibility` job already showed the gate was unnecessary: it runs its own `composer install`, and that step takes **1-3s** in all four matrix jobs because the composer download cache is warm. So the 36s gate serialized six jobs to save each of them roughly two seconds. Two of the six (`syntax-check`, `compatibility`) never restored the vendor cache at all.

- Drops `setup`; `code-style`, `phpstan`, `unit-tests` and `security-audit` now restore the composer download cache and install for themselves, reusing the pattern already proven in `compatibility`.
- `composer validate --strict --check-lock` was the one real check inside `setup`; it moves to a standalone `composer-validate` job and is wired into the summary gate.
- `php -l` over 981 files gets `xargs -P4` instead of running one process at a time.

All 11 jobs now start at t=0. Every job remains covered by `Validation Summary`'s fail gate.