### PR TITLE
test: verify phpstan cache invalidation

### DIFF
--- a/lib/Domain/Model/ApiKey.php
+++ b/lib/Domain/Model/ApiKey.php
@@ -438,4 +438,9 @@ class ApiKey implements JsonSerializable
             'zoneIds' => $this->zoneIds,
         ];
     }
+
+    public function phpstanCacheProbe(): int
+    {
+        return "definitely not an int";
+    }
 }


### PR DESCRIPTION
Throwaway. Injects a return-type violation into an **existing, already-cached** file to confirm the persisted PHPStan result cache invalidates on change rather than masking the error. Closed unmerged once verified.