### PR TITLE
chore(deps): stagger dependabot schedules across the weekend by branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@
 #
 # Note: security updates are only ever raised against master. The weekly
 # dependency-audit workflow covers the other branches.
+#
+# Each branch has its own weekend slot so a week's updates arrive as five small
+# batches instead of one burst of roughly fifteen pull requests.
 version: 2
 updates:
 
@@ -85,7 +88,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "09:00"
+      time: "13:00"
       timezone: "Europe/Vilnius"
     cooldown:
       default-days: 7
@@ -108,7 +111,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "09:00"
+      time: "13:00"
       timezone: "Europe/Vilnius"
     cooldown:
       default-days: 7
@@ -124,7 +127,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "09:00"
+      time: "13:00"
       timezone: "Europe/Vilnius"
     cooldown:
       default-days: 3
@@ -137,7 +140,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "09:00"
+      time: "13:00"
       timezone: "Europe/Vilnius"
     cooldown:
       default-days: 7
@@ -154,7 +157,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "09:00"
+      time: "17:00"
       timezone: "Europe/Vilnius"
     cooldown:
       default-days: 7
@@ -173,7 +176,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "09:00"
+      time: "17:00"
       timezone: "Europe/Vilnius"
     cooldown:
       default-days: 7
@@ -189,7 +192,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
-      time: "09:00"
+      time: "17:00"
       timezone: "Europe/Vilnius"
     cooldown:
       default-days: 3
@@ -205,7 +208,7 @@ updates:
     target-branch: "release/4.2.x"
     schedule:
       interval: "weekly"
-      day: "saturday"
+      day: "sunday"
       time: "09:00"
       timezone: "Europe/Vilnius"
     cooldown:
@@ -224,7 +227,7 @@ updates:
     target-branch: "release/4.2.x"
     schedule:
       interval: "weekly"
-      day: "saturday"
+      day: "sunday"
       time: "09:00"
       timezone: "Europe/Vilnius"
     cooldown:
@@ -240,7 +243,7 @@ updates:
     target-branch: "release/4.2.x"
     schedule:
       interval: "weekly"
-      day: "saturday"
+      day: "sunday"
       time: "09:00"
       timezone: "Europe/Vilnius"
     cooldown:
@@ -257,8 +260,8 @@ updates:
     target-branch: "release/3.x"
     schedule:
       interval: "weekly"
-      day: "saturday"
-      time: "09:00"
+      day: "sunday"
+      time: "13:00"
       timezone: "Europe/Vilnius"
     cooldown:
       default-days: 7
@@ -276,8 +279,8 @@ updates:
     target-branch: "release/3.x"
     schedule:
       interval: "weekly"
-      day: "saturday"
-      time: "09:00"
+      day: "sunday"
+      time: "13:00"
       timezone: "Europe/Vilnius"
     cooldown:
       default-days: 7
@@ -292,8 +295,8 @@ updates:
     target-branch: "release/3.x"
     schedule:
       interval: "weekly"
-      day: "saturday"
-      time: "09:00"
+      day: "sunday"
+      time: "13:00"
       timezone: "Europe/Vilnius"
     cooldown:
       default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,9 @@
 # Note: security updates are only ever raised against master. The weekly
 # dependency-audit workflow covers the other branches.
 #
-# Each branch has its own weekend slot so a week's updates arrive as five small
-# batches instead of one burst of roughly fifteen pull requests.
+# Each branch has its own weekend slot so updates arrive as small batches instead
+# of one burst of roughly fifteen pull requests. The older stable lines poll
+# monthly: they take patch updates only, and security fixes are raised on master.
 version: 2
 updates:
 
@@ -207,7 +208,7 @@ updates:
     directory: "/"
     target-branch: "release/4.2.x"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "sunday"
       time: "09:00"
       timezone: "Europe/Vilnius"
@@ -226,7 +227,7 @@ updates:
     directory: "/"
     target-branch: "release/4.2.x"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "sunday"
       time: "09:00"
       timezone: "Europe/Vilnius"
@@ -242,7 +243,7 @@ updates:
     directory: "/"
     target-branch: "release/4.2.x"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "sunday"
       time: "09:00"
       timezone: "Europe/Vilnius"
@@ -259,7 +260,7 @@ updates:
     directory: "/"
     target-branch: "release/3.x"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "sunday"
       time: "13:00"
       timezone: "Europe/Vilnius"
@@ -278,7 +279,7 @@ updates:
     directory: "/"
     target-branch: "release/3.x"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "sunday"
       time: "13:00"
       timezone: "Europe/Vilnius"
@@ -294,7 +295,7 @@ updates:
     directory: "/"
     target-branch: "release/3.x"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
       day: "sunday"
       time: "13:00"
       timezone: "Europe/Vilnius"


### PR DESCRIPTION
All 17 dependabot entries fired at Saturday 09:00, so a week's updates arrived as one burst (14 PRs this week).

Each branch now gets its own slot, and the older stable lines drop to monthly:

| Slot | Branch | Cadence |
|------|--------|---------|
| Sat 09:00 | master | weekly |
| Sat 13:00 | develop | weekly |
| Sat 17:00 | release/4.3.x | weekly |
| Sun 09:00 | release/4.2.x | monthly |
| Sun 13:00 | release/3.x | monthly |

Grouping by branch rather than by ecosystem keeps each batch a self-contained unit of work, since the composer PRs need a per-branch vendor regeneration.

release/4.2.x and release/3.x take patch updates only and security fixes are raised on master, so a weekly poll on them was mostly noise. A typical week should now be roughly 6-8 PRs in three batches rather than 14 at once.

Note: whether `day` is honoured for a monthly interval is not clearly documented. If it is, those two land on the first Sunday of the month; if not, on the 1st at the given time. Either way they stay separated from the weekly batches.

Ecosystems, groups, cooldowns and ignore rules are untouched.