### PR TITLE
chore(repo): ignore local phpstan cache and playwright sweep log directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ locale/**/*.po.backup.*
 
 # Playwright
 /playwright-report/
+/playwright-sweep-logs/
 /playwright/.cache/
 /test-results/
 *.trace.zip
@@ -69,6 +70,7 @@ locale/**/*.po.backup.*
 
 # PHP tools
 /.php-cs-fixer.cache
+/.phpstan-cache/
 .phan/phan.phar
 .phpdoc/phpDocumentor.phar
 


### PR DESCRIPTION
Both directories are produced by local tooling and neither was ignored, so they sat in `git status` permanently and could be committed by accident. They are also large: 78 MB and 17 MB in my checkout.

`/.phpstan-cache/` is a PHPStan result cache written by an ad-hoc `--tmp-dir` run, and `/playwright-sweep-logs/` holds the timestamped per-database logs from cross-DB E2E sweeps. Both regenerate on demand.

Placed under the existing Playwright and PHP tools sections.